### PR TITLE
Sketch up a simple terminal API.

### DIFF
--- a/command.md
+++ b/command.md
@@ -78,27 +78,11 @@ also known as <a href="https://en.wikipedia.org/wiki/Unix_time">Unix Time</a>.</
 at once.</p>
 <hr />
 <h3>Types</h3>
-<h4><a name="pollable"><code>type pollable</code></a></h4>
-<p><code>u32</code></p>
-<p>A "pollable" handle.
-<p>This is conceptually represents a <code>stream&lt;_, _&gt;</code>, or in other words,
-a stream that one can wait on, repeatedly, but which does not itself
-produce any data. It's temporary scaffolding until component-model's
-async features are ready.</p>
-<p>And at present, it is a <code>u32</code> instead of being an actual handle, until
-the wit-bindgen implementation of handles and resources is ready.</p>
-<p><a href="#pollable"><code>pollable</code></a> lifetimes are not automatically managed. Users must ensure
-that they do not outlive the resource they reference.</p>
-<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
+<h4><a name="pollable"><code>resource pollable</code></a></h4>
+<h5>Resource Members</h5>
+<p>TODO</p>
 <hr />
 <h3>Functions</h3>
-<h4><a name="drop_pollable"><code>drop-pollable: func</code></a></h4>
-<p>Dispose of the specified <a href="#pollable"><code>pollable</code></a>, after which it may no longer
-be used.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="drop_pollable.this"><code>this</code></a>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
-</ul>
 <h4><a name="poll_oneoff"><code>poll-oneoff: func</code></a></h4>
 <p>Poll for completion on a set of pollables.</p>
 <p>The &quot;oneoff&quot; in the name refers to the fact that this function must do a
@@ -107,18 +91,16 @@ inefficient if the number is large and the same subscriptions are used
 many times. In the future, this is expected to be obsoleted by the
 component model async proposal, which will include a scalable waiting
 facility.</p>
-<p>Note that the return type would ideally be <code>list&lt;bool&gt;</code>, but that would
-be more difficult to polyfill given the current state of <code>wit-bindgen</code>.
-See <a href="https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061">https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061</a>
-for details.  For now, we use zero to mean &quot;not ready&quot; and non-zero to
-mean &quot;ready&quot;.</p>
+<p>The result list<bool> is the same length as the argument
+list<pollable>, and indicates the readiness of each corresponding
+element in that / list, with true indicating ready.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="poll_oneoff.in"><code>in</code></a>: list&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
+<li><a name="poll_oneoff.in"><code>in</code></a>: list&lt;own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="poll_oneoff.0"></a> list&lt;<code>u8</code>&gt;</li>
+<li><a name="poll_oneoff.0"></a> list&lt;<code>bool</code>&gt;</li>
 </ul>
 <h2><a name="wasi:clocks_monotonic_clock">Import interface wasi:clocks/monotonic-clock</a></h2>
 <p>WASI Monotonic Clock is a clock API intended to let users measure elapsed
@@ -162,7 +144,7 @@ reached.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="subscribe.0"></a> <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
+<li><a name="subscribe.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:clocks_timezone">Import interface wasi:clocks/timezone</a></h2>
 <hr />
@@ -170,14 +152,17 @@ reached.</p>
 <h4><a name="datetime"><code>type datetime</code></a></h4>
 <p><a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
 <p>
-#### <a name="timezone_display">`record timezone-display`</a>
+#### <a name="timezone">`resource timezone`</a>
+<h5>Resource Members</h5>
+<p>TODO</p>
+<h4><a name="timezone_display"><code>record timezone-display</code></a></h4>
 <p>Information useful for displaying the timezone of a specific <a href="#datetime"><code>datetime</code></a>.</p>
 <p>This information may vary within a single <a href="#timezone"><code>timezone</code></a> to reflect daylight
 saving time adjustments.</p>
 <h5>Record Fields</h5>
 <ul>
 <li>
-<p><a name="timezone_display.utc_offset"><a href="#utc_offset"><code>utc-offset</code></a></a>: <code>s32</code></p>
+<p><a name="timezone_display.utc_offset"><code>utc-offset</code></a>: <code>s32</code></p>
 <p>The number of seconds difference between UTC time and the local
 time of the timezone.
 <p>The returned value will always be less than 86400 which is the
@@ -202,48 +187,34 @@ representation of the UTC offset may be returned, such as <code>-04:00</code>.</
 should return false.</p>
 </li>
 </ul>
-<h4><a name="timezone"><code>type timezone</code></a></h4>
-<p><code>u32</code></p>
-<p>A timezone.
-<p>In timezones that recognize daylight saving time, also known as daylight
-time and summer time, the information returned from the functions varies
-over time to reflect these adjustments.</p>
-<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
 <hr />
 <h3>Functions</h3>
-<h4><a name="display"><code>display: func</code></a></h4>
+<h4><a name="method_timezone.display"><code>[method]timezone.display: func</code></a></h4>
 <p>Return information needed to display the given <a href="#datetime"><code>datetime</code></a>. This includes
 the UTC offset, the time zone name, and a flag indicating whether
 daylight saving time is active.</p>
 <p>If the timezone cannot be determined for the given <a href="#datetime"><code>datetime</code></a>, return a
-<a href="#timezone_display"><code>timezone-display</code></a> for <code>UTC</code> with a <a href="#utc_offset"><code>utc-offset</code></a> of 0 and no daylight
+<a href="#timezone_display"><code>timezone-display</code></a> for <code>UTC</code> with a <code>utc-offset</code> of 0 and no daylight
 saving time.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="display.this"><code>this</code></a>: <a href="#timezone"><a href="#timezone"><code>timezone</code></a></a></li>
-<li><a name="display.when"><code>when</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
+<li><a name="method_timezone.display.self"><code>self</code></a>: borrow&lt;<a href="#timezone"><a href="#timezone"><code>timezone</code></a></a>&gt;</li>
+<li><a name="method_timezone.display.when"><code>when</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="display.0"></a> <a href="#timezone_display"><a href="#timezone_display"><code>timezone-display</code></a></a></li>
+<li><a name="method_timezone.display.0"></a> <a href="#timezone_display"><a href="#timezone_display"><code>timezone-display</code></a></a></li>
 </ul>
-<h4><a name="utc_offset"><code>utc-offset: func</code></a></h4>
-<p>The same as <a href="#display"><code>display</code></a>, but only return the UTC offset.</p>
+<h4><a name="method_timezone.utc_offset"><code>[method]timezone.utc-offset: func</code></a></h4>
+<p>The same as <code>display</code>, but only return the UTC offset.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="utc_offset.this"><code>this</code></a>: <a href="#timezone"><a href="#timezone"><code>timezone</code></a></a></li>
-<li><a name="utc_offset.when"><code>when</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
+<li><a name="method_timezone.utc_offset.self"><code>self</code></a>: borrow&lt;<a href="#timezone"><a href="#timezone"><code>timezone</code></a></a>&gt;</li>
+<li><a name="method_timezone.utc_offset.when"><code>when</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="utc_offset.0"></a> <code>s32</code></li>
-</ul>
-<h4><a name="drop_timezone"><code>drop-timezone: func</code></a></h4>
-<p>Dispose of the specified input-stream, after which it may no longer
-be used.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="drop_timezone.this"><code>this</code></a>: <a href="#timezone"><a href="#timezone"><code>timezone</code></a></a></li>
+<li><a name="method_timezone.utc_offset.0"></a> <code>s32</code></li>
 </ul>
 <h2><a name="wasi:io_streams">Import interface wasi:io/streams</a></h2>
 <p>WASI I/O is an I/O abstraction API which is currently focused on providing
@@ -259,46 +230,39 @@ when it does, they are expected to subsume this API.</p>
 <p>An error type returned from a stream operation. Currently this
 doesn't provide any additional information.</p>
 <h5>Record Fields</h5>
-<h4><a name="output_stream"><code>type output-stream</code></a></h4>
-<p><code>u32</code></p>
-<p>An output bytestream. In the future, this will be replaced by handle
-types.
-<p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
-scaffolding until component-model's async features are ready.</p>
-<p><a href="#output_stream"><code>output-stream</code></a>s are <em>non-blocking</em> to the extent practical on
-underlying platforms. Except where specified otherwise, I/O operations also
-always return promptly, after the number of bytes that can be written
-promptly, which could even be zero. To wait for the stream to be ready to
-accept data, the <a href="#subscribe_to_output_stream"><code>subscribe-to-output-stream</code></a> function to obtain a
-<a href="#pollable"><code>pollable</code></a> which can be polled for using <code>wasi_poll</code>.</p>
-<p>And at present, it is a <code>u32</code> instead of being an actual handle, until
-the wit-bindgen implementation of handles and resources is ready.</p>
-<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
-<h4><a name="input_stream"><code>type input-stream</code></a></h4>
-<p><code>u32</code></p>
-<p>An input bytestream. In the future, this will be replaced by handle
-types.
-<p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
-scaffolding until component-model's async features are ready.</p>
-<p><a href="#input_stream"><code>input-stream</code></a>s are <em>non-blocking</em> to the extent practical on underlying
-platforms. I/O operations always return promptly; if fewer bytes are
-promptly available than requested, they return the number of bytes promptly
-available, which could even be zero. To wait for data to be available,
-use the <a href="#subscribe_to_input_stream"><code>subscribe-to-input-stream</code></a> function to obtain a <a href="#pollable"><code>pollable</code></a> which
-can be polled for using <code>wasi_poll</code>.</p>
-<p>And at present, it is a <code>u32</code> instead of being an actual handle, until
-the wit-bindgen implementation of handles and resources is ready.</p>
-<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
+<h4><a name="stream_status"><code>enum stream-status</code></a></h4>
+<p>Streams provide a sequence of data and then end; once they end, they
+no longer provide any further data.</p>
+<p>For example, a stream reading from a file ends when the stream reaches
+the end of the file. For another example, a stream reading from a
+socket ends when the socket is closed.</p>
+<h5>Enum Cases</h5>
+<ul>
+<li>
+<p><a name="stream_status.open"><code>open</code></a></p>
+<p>The stream is open and may produce further data.
+</li>
+<li>
+<p><a name="stream_status.ended"><code>ended</code></a></p>
+<p>The stream has ended and will not produce any further data.
+</li>
+</ul>
+<h4><a name="input_stream"><code>resource input-stream</code></a></h4>
+<h5>Resource Members</h5>
+<p>TODO</p>
+<h4><a name="output_stream"><code>resource output-stream</code></a></h4>
+<h5>Resource Members</h5>
+<p>TODO</p>
 <hr />
 <h3>Functions</h3>
-<h4><a name="read"><code>read: func</code></a></h4>
+<h4><a name="method_input_stream.read"><code>[method]input-stream.read: func</code></a></h4>
 <p>Read bytes from a stream.</p>
 <p>This function returns a list of bytes containing the data that was
-read, along with a bool which, when true, indicates that the end of the
-stream was reached. The returned list will contain up to <code>len</code> bytes; it
-may return fewer than requested, but not more.</p>
+read, along with a <a href="#stream_status"><code>stream-status</code></a> which indicates whether the end of
+the stream was reached. The returned list will contain up to <code>len</code>
+bytes; it may return fewer than requested, but not more.</p>
 <p>Once a stream has reached the end, subsequent calls to read or
-<a href="#skip"><code>skip</code></a> will always report end-of-stream rather than producing more
+<code>skip</code> will always report end-of-stream rather than producing more
 data.</p>
 <p>If <code>len</code> is 0, it represents a request to read 0 bytes, which should
 always succeed, assuming the stream hasn't reached its end yet, and
@@ -308,130 +272,123 @@ a buffer as large as that would imply.
 FIXME: describe what happens if allocation fails.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="read.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
-<li><a name="read.len"><code>len</code></a>: <code>u64</code></li>
+<li><a name="method_input_stream.read.self"><code>self</code></a>: borrow&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;</li>
+<li><a name="method_input_stream.read.len"><code>len</code></a>: <code>u64</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="method_input_stream.read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
-<h4><a name="blocking_read"><code>blocking-read: func</code></a></h4>
+<h4><a name="method_input_stream.blocking_read"><code>[method]input-stream.blocking-read: func</code></a></h4>
 <p>Read bytes from a stream, with blocking.</p>
-<p>This is similar to <a href="#read"><code>read</code></a>, except that it blocks until at least one
+<p>This is similar to <code>read</code>, except that it blocks until at least one
 byte can be read.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="blocking_read.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
-<li><a name="blocking_read.len"><code>len</code></a>: <code>u64</code></li>
+<li><a name="method_input_stream.blocking_read.self"><code>self</code></a>: borrow&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;</li>
+<li><a name="method_input_stream.blocking_read.len"><code>len</code></a>: <code>u64</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="blocking_read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="method_input_stream.blocking_read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
-<h4><a name="skip"><code>skip: func</code></a></h4>
+<h4><a name="method_input_stream.skip"><code>[method]input-stream.skip: func</code></a></h4>
 <p>Skip bytes from a stream.</p>
-<p>This is similar to the <a href="#read"><code>read</code></a> function, but avoids copying the
+<p>This is similar to the <code>read</code> function, but avoids copying the
 bytes into the instance.</p>
 <p>Once a stream has reached the end, subsequent calls to read or
-<a href="#skip"><code>skip</code></a> will always report end-of-stream rather than producing more
+<code>skip</code> will always report end-of-stream rather than producing more
 data.</p>
-<p>This function returns the number of bytes skipped, along with a bool
-indicating whether the end of the stream was reached. The returned
-value will be at most <code>len</code>; it may be less.</p>
+<p>This function returns the number of bytes skipped, along with a
+<a href="#stream_status"><code>stream-status</code></a> indicating whether the end of the stream was
+reached. The returned value will be at most <code>len</code>; it may be less.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="skip.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
-<li><a name="skip.len"><code>len</code></a>: <code>u64</code></li>
+<li><a name="method_input_stream.skip.self"><code>self</code></a>: borrow&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;</li>
+<li><a name="method_input_stream.skip.len"><code>len</code></a>: <code>u64</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="skip.0"></a> result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="method_input_stream.skip.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
-<h4><a name="blocking_skip"><code>blocking-skip: func</code></a></h4>
+<h4><a name="method_input_stream.blocking_skip"><code>[method]input-stream.blocking-skip: func</code></a></h4>
 <p>Skip bytes from a stream, with blocking.</p>
-<p>This is similar to <a href="#skip"><code>skip</code></a>, except that it blocks until at least one
+<p>This is similar to <code>skip</code>, except that it blocks until at least one
 byte can be consumed.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="blocking_skip.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
-<li><a name="blocking_skip.len"><code>len</code></a>: <code>u64</code></li>
+<li><a name="method_input_stream.blocking_skip.self"><code>self</code></a>: borrow&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;</li>
+<li><a name="method_input_stream.blocking_skip.len"><code>len</code></a>: <code>u64</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="blocking_skip.0"></a> result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="method_input_stream.blocking_skip.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
-<h4><a name="subscribe_to_input_stream"><code>subscribe-to-input-stream: func</code></a></h4>
+<h4><a name="method_input_stream.subscribe_to_input_stream"><code>[method]input-stream.subscribe-to-input-stream: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream
 has bytes available to read or the other end of the stream has been
 closed.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="subscribe_to_input_stream.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+<li><a name="method_input_stream.subscribe_to_input_stream.self"><code>self</code></a>: borrow&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="subscribe_to_input_stream.0"></a> <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
+<li><a name="method_input_stream.subscribe_to_input_stream.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
 </ul>
-<h4><a name="drop_input_stream"><code>drop-input-stream: func</code></a></h4>
-<p>Dispose of the specified <a href="#input_stream"><code>input-stream</code></a>, after which it may no longer
-be used.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="drop_input_stream.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
-</ul>
-<h4><a name="write"><code>write: func</code></a></h4>
+<h4><a name="method_output_stream.write"><code>[method]output-stream.write: func</code></a></h4>
 <p>Write bytes to a stream.</p>
 <p>This function returns a <code>u64</code> indicating the number of bytes from
 <code>buf</code> that were written; it may be less than the full list.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="write.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
-<li><a name="write.buf"><code>buf</code></a>: list&lt;<code>u8</code>&gt;</li>
+<li><a name="method_output_stream.write.self"><code>self</code></a>: borrow&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;</li>
+<li><a name="method_output_stream.write.buf"><code>buf</code></a>: list&lt;<code>u8</code>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="write.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.write.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
-<h4><a name="blocking_write"><code>blocking-write: func</code></a></h4>
+<h4><a name="method_output_stream.blocking_write"><code>[method]output-stream.blocking-write: func</code></a></h4>
 <p>Write bytes to a stream, with blocking.</p>
-<p>This is similar to <a href="#write"><code>write</code></a>, except that it blocks until at least one
+<p>This is similar to <code>write</code>, except that it blocks until at least one
 byte can be written.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="blocking_write.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
-<li><a name="blocking_write.buf"><code>buf</code></a>: list&lt;<code>u8</code>&gt;</li>
+<li><a name="method_output_stream.blocking_write.self"><code>self</code></a>: borrow&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;</li>
+<li><a name="method_output_stream.blocking_write.buf"><code>buf</code></a>: list&lt;<code>u8</code>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="blocking_write.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.blocking_write.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
-<h4><a name="write_zeroes"><code>write-zeroes: func</code></a></h4>
+<h4><a name="method_output_stream.write_zeroes"><code>[method]output-stream.write-zeroes: func</code></a></h4>
 <p>Write multiple zero bytes to a stream.</p>
 <p>This function returns a <code>u64</code> indicating the number of zero bytes
 that were written; it may be less than <code>len</code>.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="write_zeroes.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
-<li><a name="write_zeroes.len"><code>len</code></a>: <code>u64</code></li>
+<li><a name="method_output_stream.write_zeroes.self"><code>self</code></a>: borrow&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;</li>
+<li><a name="method_output_stream.write_zeroes.len"><code>len</code></a>: <code>u64</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="write_zeroes.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.write_zeroes.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
-<h4><a name="blocking_write_zeroes"><code>blocking-write-zeroes: func</code></a></h4>
+<h4><a name="method_output_stream.blocking_write_zeroes"><code>[method]output-stream.blocking-write-zeroes: func</code></a></h4>
 <p>Write multiple zero bytes to a stream, with blocking.</p>
-<p>This is similar to <a href="#write_zeroes"><code>write-zeroes</code></a>, except that it blocks until at least
+<p>This is similar to <code>write-zeroes</code>, except that it blocks until at least
 one byte can be written.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="blocking_write_zeroes.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
-<li><a name="blocking_write_zeroes.len"><code>len</code></a>: <code>u64</code></li>
+<li><a name="method_output_stream.blocking_write_zeroes.self"><code>self</code></a>: borrow&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;</li>
+<li><a name="method_output_stream.blocking_write_zeroes.len"><code>len</code></a>: <code>u64</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="blocking_write_zeroes.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.blocking_write_zeroes.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
-<h4><a name="splice"><code>splice: func</code></a></h4>
+<h4><a name="method_output_stream.splice"><code>[method]output-stream.splice: func</code></a></h4>
 <p>Read from one stream and write to another.</p>
 <p>This function returns the number of bytes transferred; it may be less
 than <code>len</code>.</p>
@@ -439,29 +396,29 @@ than <code>len</code>.</p>
 read from the input stream has been written to the output stream.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="splice.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
-<li><a name="splice.src"><code>src</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
-<li><a name="splice.len"><code>len</code></a>: <code>u64</code></li>
+<li><a name="method_output_stream.splice.self"><code>self</code></a>: borrow&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;</li>
+<li><a name="method_output_stream.splice.src"><code>src</code></a>: own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;</li>
+<li><a name="method_output_stream.splice.len"><code>len</code></a>: <code>u64</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="splice.0"></a> result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.splice.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
-<h4><a name="blocking_splice"><code>blocking-splice: func</code></a></h4>
+<h4><a name="method_output_stream.blocking_splice"><code>[method]output-stream.blocking-splice: func</code></a></h4>
 <p>Read from one stream and write to another, with blocking.</p>
-<p>This is similar to <a href="#splice"><code>splice</code></a>, except that it blocks until at least
+<p>This is similar to <code>splice</code>, except that it blocks until at least
 one byte can be read.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="blocking_splice.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
-<li><a name="blocking_splice.src"><code>src</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
-<li><a name="blocking_splice.len"><code>len</code></a>: <code>u64</code></li>
+<li><a name="method_output_stream.blocking_splice.self"><code>self</code></a>: borrow&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;</li>
+<li><a name="method_output_stream.blocking_splice.src"><code>src</code></a>: own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;</li>
+<li><a name="method_output_stream.blocking_splice.len"><code>len</code></a>: <code>u64</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="blocking_splice.0"></a> result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.blocking_splice.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
-<h4><a name="forward"><code>forward: func</code></a></h4>
+<h4><a name="method_output_stream.forward"><code>[method]output-stream.forward: func</code></a></h4>
 <p>Forward the entire contents of an input stream to an output stream.</p>
 <p>This function repeatedly reads from the input stream and writes
 the data to the output stream, until the end of the input stream
@@ -472,30 +429,23 @@ the output stream.</p>
 <p>This function returns the number of bytes transferred.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="forward.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
-<li><a name="forward.src"><code>src</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+<li><a name="method_output_stream.forward.self"><code>self</code></a>: borrow&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;</li>
+<li><a name="method_output_stream.forward.src"><code>src</code></a>: own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="forward.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.forward.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
-<h4><a name="subscribe_to_output_stream"><code>subscribe-to-output-stream: func</code></a></h4>
+<h4><a name="method_output_stream.subscribe_to_output_stream"><code>[method]output-stream.subscribe-to-output-stream: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream
 is ready to accept bytes or the other end of the stream has been closed.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="subscribe_to_output_stream.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a name="method_output_stream.subscribe_to_output_stream.self"><code>self</code></a>: borrow&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="subscribe_to_output_stream.0"></a> <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
-</ul>
-<h4><a name="drop_output_stream"><code>drop-output-stream: func</code></a></h4>
-<p>Dispose of the specified <a href="#output_stream"><code>output-stream</code></a>, after which it may no longer
-be used.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="drop_output_stream.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a name="method_output_stream.subscribe_to_output_stream.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:filesystem_types">Import interface wasi:filesystem/types</a></h2>
 <p>WASI filesystem is a filesystem API primarily intended to let users run WASI
@@ -524,7 +474,108 @@ underlying filesystem, the function fails with <a href="#error_code.not_permitte
 #### <a name="datetime">`type datetime`</a>
 [`datetime`](#datetime)
 <p>
-#### <a name="path_flags">`flags path-flags`</a>
+#### <a name="filesize">`type filesize`</a>
+`u64`
+<p>File size or length of a region within a file.
+<h4><a name="descriptor_type"><code>enum descriptor-type</code></a></h4>
+<p>The type of a filesystem object referenced by a descriptor.</p>
+<p>Note: This was called <code>filetype</code> in earlier versions of WASI.</p>
+<h5>Enum Cases</h5>
+<ul>
+<li>
+<p><a name="descriptor_type.unknown"><code>unknown</code></a></p>
+<p>The type of the descriptor or file is unknown or is different from
+any of the other types specified.
+</li>
+<li>
+<p><a name="descriptor_type.block_device"><code>block-device</code></a></p>
+<p>The descriptor refers to a block device inode.
+</li>
+<li>
+<p><a name="descriptor_type.character_device"><code>character-device</code></a></p>
+<p>The descriptor refers to a character device inode.
+</li>
+<li>
+<p><a name="descriptor_type.directory"><code>directory</code></a></p>
+<p>The descriptor refers to a directory inode.
+</li>
+<li>
+<p><a name="descriptor_type.fifo"><code>fifo</code></a></p>
+<p>The descriptor refers to a named pipe.
+</li>
+<li>
+<p><a name="descriptor_type.symbolic_link"><code>symbolic-link</code></a></p>
+<p>The file refers to a symbolic link inode.
+</li>
+<li>
+<p><a name="descriptor_type.regular_file"><code>regular-file</code></a></p>
+<p>The descriptor refers to a regular file inode.
+</li>
+<li>
+<p><a name="descriptor_type.socket"><code>socket</code></a></p>
+<p>The descriptor refers to a socket.
+</li>
+</ul>
+<h4><a name="descriptor_flags"><code>flags descriptor-flags</code></a></h4>
+<p>Descriptor flags.</p>
+<p>Note: This was called <code>fdflags</code> in earlier versions of WASI.</p>
+<h5>Flags members</h5>
+<ul>
+<li>
+<p><a name="descriptor_flags.read"><code>read</code></a>: </p>
+<p>Read mode: Data can be read.
+</li>
+<li>
+<p><a name="descriptor_flags.write"><code>write</code></a>: </p>
+<p>Write mode: Data can be written to.
+</li>
+<li>
+<p><a name="descriptor_flags.non_blocking"><code>non-blocking</code></a>: </p>
+<p>Requests non-blocking operation.
+<p>When this flag is enabled, functions may return immediately with an
+<a href="#error_code.would_block"><code>error-code::would-block</code></a> error code in situations where they would
+otherwise block. However, this non-blocking behavior is not
+required. Implementations are permitted to ignore this flag and
+block. This is similar to <code>O_NONBLOCK</code> in POSIX.</p>
+</li>
+<li>
+<p><a name="descriptor_flags.file_integrity_sync"><code>file-integrity-sync</code></a>: </p>
+<p>Request that writes be performed according to synchronized I/O file
+integrity completion. The data stored in the file and the file's
+metadata are synchronized. This is similar to `O_SYNC` in POSIX.
+<p>The precise semantics of this operation have not yet been defined for
+WASI. At this time, it should be interpreted as a request, and not a
+requirement.</p>
+</li>
+<li>
+<p><a name="descriptor_flags.data_integrity_sync"><code>data-integrity-sync</code></a>: </p>
+<p>Request that writes be performed according to synchronized I/O data
+integrity completion. Only the data stored in the file is
+synchronized. This is similar to `O_DSYNC` in POSIX.
+<p>The precise semantics of this operation have not yet been defined for
+WASI. At this time, it should be interpreted as a request, and not a
+requirement.</p>
+</li>
+<li>
+<p><a name="descriptor_flags.requested_write_sync"><code>requested-write-sync</code></a>: </p>
+<p>Requests that reads be performed at the same level of integrety
+requested for writes. This is similar to `O_RSYNC` in POSIX.
+<p>The precise semantics of this operation have not yet been defined for
+WASI. At this time, it should be interpreted as a request, and not a
+requirement.</p>
+</li>
+<li>
+<p><a name="descriptor_flags.mutate_directory"><code>mutate-directory</code></a>: </p>
+<p>Mutating directories mode: Directory contents may be mutated.
+<p>When this flag is unset on a descriptor, operations using the
+descriptor which would create, rename, delete, modify the data or
+metadata of filesystem objects, or obtain another handle which
+would permit any of those, shall fail with <a href="#error_code.read_only"><code>error-code::read-only</code></a> if
+they would otherwise succeed.</p>
+<p>This may only be set on directories.</p>
+</li>
+</ul>
+<h4><a name="path_flags"><code>flags path-flags</code></a></h4>
 <p>Flags determining the method of how paths are resolved.</p>
 <h5>Flags members</h5>
 <ul>
@@ -533,7 +584,7 @@ expanded.
 </li>
 </ul>
 <h4><a name="open_flags"><code>flags open-flags</code></a></h4>
-<p>Open flags used by <a href="#open_at"><code>open-at</code></a>.</p>
+<p>Open flags used by <code>open-at</code>.</p>
 <h5>Flags members</h5>
 <ul>
 <li>
@@ -554,7 +605,7 @@ expanded.
 </li>
 </ul>
 <h4><a name="modes"><code>flags modes</code></a></h4>
-<p>Permissions mode used by <a href="#open_at"><code>open-at</code></a>, <a href="#change_file_permissions_at"><code>change-file-permissions-at</code></a>, and
+<p>Permissions mode used by <code>open-at</code>, <code>change-file-permissions-at</code>, and
 similar.</p>
 <h5>Flags members</h5>
 <ul>
@@ -574,15 +625,108 @@ filesystem.
 filesystem. This does not apply to directories.
 </li>
 </ul>
+<h4><a name="access_type"><code>variant access-type</code></a></h4>
+<p>Access type used by <code>access-at</code>.</p>
+<h5>Variant Cases</h5>
+<ul>
+<li>
+<p><a name="access_type.access"><code>access</code></a>: <a href="#modes"><a href="#modes"><code>modes</code></a></a></p>
+<p>Test for readability, writeability, or executability.
+</li>
+<li>
+<p><a name="access_type.exists"><code>exists</code></a></p>
+<p>Test whether the path exists.
+</li>
+</ul>
 <h4><a name="link_count"><code>type link-count</code></a></h4>
 <p><code>u64</code></p>
 <p>Number of hard links to an inode.
+<h4><a name="device"><code>type device</code></a></h4>
+<p><code>u64</code></p>
+<p>Identifier for a device containing a file system. Can be used in
+combination with `inode` to uniquely identify a file or directory in
+the filesystem.
 <h4><a name="inode"><code>type inode</code></a></h4>
 <p><code>u64</code></p>
 <p>Filesystem object serial number that is unique within its file system.
-<h4><a name="filesize"><code>type filesize</code></a></h4>
-<p><code>u64</code></p>
-<p>File size or length of a region within a file.
+<h4><a name="descriptor_stat"><code>record descriptor-stat</code></a></h4>
+<p>File attributes.</p>
+<p>Note: This was called <code>filestat</code> in earlier versions of WASI.</p>
+<h5>Record Fields</h5>
+<ul>
+<li>
+<p><a name="descriptor_stat.device"><a href="#device"><code>device</code></a></a>: <a href="#device"><a href="#device"><code>device</code></a></a></p>
+<p>Device ID of device containing the file.
+</li>
+<li>
+<p><a name="descriptor_stat.inode"><a href="#inode"><code>inode</code></a></a>: <a href="#inode"><a href="#inode"><code>inode</code></a></a></p>
+<p>File serial number.
+</li>
+<li>
+<p><a name="descriptor_stat.type"><code>type</code></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
+<p>File type.
+</li>
+<li>
+<p><a name="descriptor_stat.link_count"><a href="#link_count"><code>link-count</code></a></a>: <a href="#link_count"><a href="#link_count"><code>link-count</code></a></a></p>
+<p>Number of hard links to the file.
+</li>
+<li>
+<p><a name="descriptor_stat.size"><code>size</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></p>
+<p>For regular files, the file size in bytes. For symbolic links, the
+length in bytes of the pathname contained in the symbolic link.
+</li>
+<li>
+<p><a name="descriptor_stat.data_access_timestamp"><code>data-access-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p>Last data access timestamp.
+</li>
+<li>
+<p><a name="descriptor_stat.data_modification_timestamp"><code>data-modification-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p>Last data modification timestamp.
+</li>
+<li>
+<p><a name="descriptor_stat.status_change_timestamp"><code>status-change-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p>Last file status change timestamp.
+</li>
+</ul>
+<h4><a name="new_timestamp"><code>variant new-timestamp</code></a></h4>
+<p>When setting a timestamp, this gives the value to set it to.</p>
+<h5>Variant Cases</h5>
+<ul>
+<li>
+<p><a name="new_timestamp.no_change"><code>no-change</code></a></p>
+<p>Leave the timestamp set to its previous value.
+</li>
+<li>
+<p><a name="new_timestamp.now"><a href="#now"><code>now</code></a></a></p>
+<p>Set the timestamp to the current time of the system clock associated
+with the filesystem.
+</li>
+<li>
+<p><a name="new_timestamp.timestamp"><code>timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p>Set the timestamp to the given value.
+</li>
+</ul>
+<h4><a name="directory_entry"><code>record directory-entry</code></a></h4>
+<p>A directory entry.</p>
+<h5>Record Fields</h5>
+<ul>
+<li>
+<p><a name="directory_entry.inode"><a href="#inode"><code>inode</code></a></a>: option&lt;<a href="#inode"><a href="#inode"><code>inode</code></a></a>&gt;</p>
+<p>The serial number of the object referred to by this directory entry.
+May be none if the inode value is not known.
+<p>When this is none, libc implementations might do an extra <code>stat-at</code>
+call to retrieve the inode number to fill their <code>d_ino</code> fields, so
+implementations which can set this to a non-none value should do so.</p>
+</li>
+<li>
+<p><a name="directory_entry.type"><code>type</code></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
+<p>The type of the file referred to by this directory entry.
+</li>
+<li>
+<p><a name="directory_entry.name"><code>name</code></a>: <code>string</code></p>
+<p>The name of the object.
+</li>
+</ul>
 <h4><a name="error_code"><code>enum error-code</code></a></h4>
 <p>Error codes returned by functions, similar to <code>errno</code> in POSIX.
 Not all of these error codes are returned by the functions provided by this
@@ -739,197 +883,6 @@ merely for alignment with POSIX.</p>
 <p>Cross-device link, similar to `EXDEV` in POSIX.
 </li>
 </ul>
-<h4><a name="directory_entry_stream"><code>type directory-entry-stream</code></a></h4>
-<p><code>u32</code></p>
-<p>A stream of directory entries.
-<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Streams">represents a stream of <code>dir-entry</code></a>.</p>
-<h4><a name="device"><code>type device</code></a></h4>
-<p><code>u64</code></p>
-<p>Identifier for a device containing a file system. Can be used in
-combination with `inode` to uniquely identify a file or directory in
-the filesystem.
-<h4><a name="descriptor_type"><code>enum descriptor-type</code></a></h4>
-<p>The type of a filesystem object referenced by a descriptor.</p>
-<p>Note: This was called <code>filetype</code> in earlier versions of WASI.</p>
-<h5>Enum Cases</h5>
-<ul>
-<li>
-<p><a name="descriptor_type.unknown"><code>unknown</code></a></p>
-<p>The type of the descriptor or file is unknown or is different from
-any of the other types specified.
-</li>
-<li>
-<p><a name="descriptor_type.block_device"><code>block-device</code></a></p>
-<p>The descriptor refers to a block device inode.
-</li>
-<li>
-<p><a name="descriptor_type.character_device"><code>character-device</code></a></p>
-<p>The descriptor refers to a character device inode.
-</li>
-<li>
-<p><a name="descriptor_type.directory"><code>directory</code></a></p>
-<p>The descriptor refers to a directory inode.
-</li>
-<li>
-<p><a name="descriptor_type.fifo"><code>fifo</code></a></p>
-<p>The descriptor refers to a named pipe.
-</li>
-<li>
-<p><a name="descriptor_type.symbolic_link"><code>symbolic-link</code></a></p>
-<p>The file refers to a symbolic link inode.
-</li>
-<li>
-<p><a name="descriptor_type.regular_file"><code>regular-file</code></a></p>
-<p>The descriptor refers to a regular file inode.
-</li>
-<li>
-<p><a name="descriptor_type.socket"><code>socket</code></a></p>
-<p>The descriptor refers to a socket.
-</li>
-</ul>
-<h4><a name="directory_entry"><code>record directory-entry</code></a></h4>
-<p>A directory entry.</p>
-<h5>Record Fields</h5>
-<ul>
-<li>
-<p><a name="directory_entry.inode"><a href="#inode"><code>inode</code></a></a>: option&lt;<a href="#inode"><a href="#inode"><code>inode</code></a></a>&gt;</p>
-<p>The serial number of the object referred to by this directory entry.
-May be none if the inode value is not known.
-<p>When this is none, libc implementations might do an extra <a href="#stat_at"><code>stat-at</code></a>
-call to retrieve the inode number to fill their <code>d_ino</code> fields, so
-implementations which can set this to a non-none value should do so.</p>
-</li>
-<li>
-<p><a name="directory_entry.type"><code>type</code></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
-<p>The type of the file referred to by this directory entry.
-</li>
-<li>
-<p><a name="directory_entry.name"><code>name</code></a>: <code>string</code></p>
-<p>The name of the object.
-</li>
-</ul>
-<h4><a name="descriptor_flags"><code>flags descriptor-flags</code></a></h4>
-<p>Descriptor flags.</p>
-<p>Note: This was called <code>fdflags</code> in earlier versions of WASI.</p>
-<h5>Flags members</h5>
-<ul>
-<li>
-<p><a name="descriptor_flags.read"><a href="#read"><code>read</code></a></a>: </p>
-<p>Read mode: Data can be read.
-</li>
-<li>
-<p><a name="descriptor_flags.write"><a href="#write"><code>write</code></a></a>: </p>
-<p>Write mode: Data can be written to.
-</li>
-<li>
-<p><a name="descriptor_flags.non_blocking"><code>non-blocking</code></a>: </p>
-<p>Requests non-blocking operation.
-<p>When this flag is enabled, functions may return immediately with an
-<a href="#error_code.would_block"><code>error-code::would-block</code></a> error code in situations where they would
-otherwise block. However, this non-blocking behavior is not
-required. Implementations are permitted to ignore this flag and
-block. This is similar to <code>O_NONBLOCK</code> in POSIX.</p>
-</li>
-<li>
-<p><a name="descriptor_flags.file_integrity_sync"><code>file-integrity-sync</code></a>: </p>
-<p>Request that writes be performed according to synchronized I/O file
-integrity completion. The data stored in the file and the file's
-metadata are synchronized. This is similar to `O_SYNC` in POSIX.
-<p>The precise semantics of this operation have not yet been defined for
-WASI. At this time, it should be interpreted as a request, and not a
-requirement.</p>
-</li>
-<li>
-<p><a name="descriptor_flags.data_integrity_sync"><code>data-integrity-sync</code></a>: </p>
-<p>Request that writes be performed according to synchronized I/O data
-integrity completion. Only the data stored in the file is
-synchronized. This is similar to `O_DSYNC` in POSIX.
-<p>The precise semantics of this operation have not yet been defined for
-WASI. At this time, it should be interpreted as a request, and not a
-requirement.</p>
-</li>
-<li>
-<p><a name="descriptor_flags.requested_write_sync"><code>requested-write-sync</code></a>: </p>
-<p>Requests that reads be performed at the same level of integrety
-requested for writes. This is similar to `O_RSYNC` in POSIX.
-<p>The precise semantics of this operation have not yet been defined for
-WASI. At this time, it should be interpreted as a request, and not a
-requirement.</p>
-</li>
-<li>
-<p><a name="descriptor_flags.mutate_directory"><code>mutate-directory</code></a>: </p>
-<p>Mutating directories mode: Directory contents may be mutated.
-<p>When this flag is unset on a descriptor, operations using the
-descriptor which would create, rename, delete, modify the data or
-metadata of filesystem objects, or obtain another handle which
-would permit any of those, shall fail with <a href="#error_code.read_only"><code>error-code::read-only</code></a> if
-they would otherwise succeed.</p>
-<p>This may only be set on directories.</p>
-</li>
-</ul>
-<h4><a name="descriptor"><code>type descriptor</code></a></h4>
-<p><code>u32</code></p>
-<p>A descriptor is a reference to a filesystem object, which may be a file,
-directory, named pipe, special file, or other object on which filesystem
-calls may be made.
-<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
-<h4><a name="new_timestamp"><code>variant new-timestamp</code></a></h4>
-<p>When setting a timestamp, this gives the value to set it to.</p>
-<h5>Variant Cases</h5>
-<ul>
-<li>
-<p><a name="new_timestamp.no_change"><code>no-change</code></a></p>
-<p>Leave the timestamp set to its previous value.
-</li>
-<li>
-<p><a name="new_timestamp.now"><a href="#now"><code>now</code></a></a></p>
-<p>Set the timestamp to the current time of the system clock associated
-with the filesystem.
-</li>
-<li>
-<p><a name="new_timestamp.timestamp"><code>timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
-<p>Set the timestamp to the given value.
-</li>
-</ul>
-<h4><a name="descriptor_stat"><code>record descriptor-stat</code></a></h4>
-<p>File attributes.</p>
-<p>Note: This was called <code>filestat</code> in earlier versions of WASI.</p>
-<h5>Record Fields</h5>
-<ul>
-<li>
-<p><a name="descriptor_stat.device"><a href="#device"><code>device</code></a></a>: <a href="#device"><a href="#device"><code>device</code></a></a></p>
-<p>Device ID of device containing the file.
-</li>
-<li>
-<p><a name="descriptor_stat.inode"><a href="#inode"><code>inode</code></a></a>: <a href="#inode"><a href="#inode"><code>inode</code></a></a></p>
-<p>File serial number.
-</li>
-<li>
-<p><a name="descriptor_stat.type"><code>type</code></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
-<p>File type.
-</li>
-<li>
-<p><a name="descriptor_stat.link_count"><a href="#link_count"><code>link-count</code></a></a>: <a href="#link_count"><a href="#link_count"><code>link-count</code></a></a></p>
-<p>Number of hard links to the file.
-</li>
-<li>
-<p><a name="descriptor_stat.size"><code>size</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></p>
-<p>For regular files, the file size in bytes. For symbolic links, the
-length in bytes of the pathname contained in the symbolic link.
-</li>
-<li>
-<p><a name="descriptor_stat.data_access_timestamp"><code>data-access-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
-<p>Last data access timestamp.
-</li>
-<li>
-<p><a name="descriptor_stat.data_modification_timestamp"><code>data-modification-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
-<p>Last data modification timestamp.
-</li>
-<li>
-<p><a name="descriptor_stat.status_change_timestamp"><code>status-change-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
-<p>Last file status change timestamp.
-</li>
-</ul>
 <h4><a name="advice"><code>enum advice</code></a></h4>
 <p>File or memory access pattern advisory information.</p>
 <h5>Enum Cases</h5>
@@ -965,158 +918,154 @@ in the near future.
 not reuse it thereafter.
 </li>
 </ul>
-<h4><a name="access_type"><code>variant access-type</code></a></h4>
-<p>Access type used by <a href="#access_at"><code>access-at</code></a>.</p>
-<h5>Variant Cases</h5>
-<ul>
-<li>
-<p><a name="access_type.access"><code>access</code></a>: <a href="#modes"><a href="#modes"><code>modes</code></a></a></p>
-<p>Test for readability, writeability, or executability.
-</li>
-<li>
-<p><a name="access_type.exists"><code>exists</code></a></p>
-<p>Test whether the path exists.
-</li>
-</ul>
+<h4><a name="descriptor"><code>resource descriptor</code></a></h4>
+<h5>Resource Members</h5>
+<p>TODO</p>
+<h4><a name="directory_entry_stream"><code>resource directory-entry-stream</code></a></h4>
+<h5>Resource Members</h5>
+<p>TODO</p>
 <hr />
 <h3>Functions</h3>
-<h4><a name="read_via_stream"><code>read-via-stream: func</code></a></h4>
-<p>Return a stream for reading from a file.</p>
+<h4><a name="method_descriptor.read_via_stream"><code>[method]descriptor.read-via-stream: func</code></a></h4>
+<p>Return a stream for reading from a file, if available.</p>
+<p>May fail with an error-code describing why the file cannot be read.</p>
 <p>Multiple read, write, and append streams may be active on the same open
 file and they do not interfere with each other.</p>
-<p>Note: This allows using <code>read-stream</code>, which is similar to <a href="#read"><code>read</code></a> in POSIX.</p>
+<p>Note: This allows using <code>read-stream</code>, which is similar to <code>read</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="read_via_stream.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="read_via_stream.offset"><code>offset</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+<li><a name="method_descriptor.read_via_stream.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.read_via_stream.offset"><code>offset</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="read_via_stream.0"></a> <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+<li><a name="method_descriptor.read_via_stream.0"></a> result&lt;own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="write_via_stream"><code>write-via-stream: func</code></a></h4>
-<p>Return a stream for writing to a file.</p>
-<p>Note: This allows using <code>write-stream</code>, which is similar to <a href="#write"><code>write</code></a> in
+<h4><a name="method_descriptor.write_via_stream"><code>[method]descriptor.write-via-stream: func</code></a></h4>
+<p>Return a stream for writing to a file, if available.</p>
+<p>May fail with an error-code describing why the file cannot be written.</p>
+<p>Note: This allows using <code>write-stream</code>, which is similar to <code>write</code> in
 POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="write_via_stream.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="write_via_stream.offset"><code>offset</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+<li><a name="method_descriptor.write_via_stream.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.write_via_stream.offset"><code>offset</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="write_via_stream.0"></a> <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a name="method_descriptor.write_via_stream.0"></a> result&lt;own&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="append_via_stream"><code>append-via-stream: func</code></a></h4>
-<p>Return a stream for appending to a file.</p>
-<p>Note: This allows using <code>write-stream</code>, which is similar to <a href="#write"><code>write</code></a> with
+<h4><a name="method_descriptor.append_via_stream"><code>[method]descriptor.append-via-stream: func</code></a></h4>
+<p>Return a stream for appending to a file, if available.</p>
+<p>May fail with an error-code describing why the file cannot be appended.</p>
+<p>Note: This allows using <code>write-stream</code>, which is similar to <code>write</code> with
 <code>O_APPEND</code> in in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="append_via_stream.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a name="method_descriptor.append_via_stream.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="append_via_stream.0"></a> <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a name="method_descriptor.append_via_stream.0"></a> result&lt;own&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="advise"><code>advise: func</code></a></h4>
+<h4><a name="method_descriptor.advise"><code>[method]descriptor.advise: func</code></a></h4>
 <p>Provide file advisory information on a descriptor.</p>
 <p>This is similar to <code>posix_fadvise</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="advise.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="advise.offset"><code>offset</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
-<li><a name="advise.length"><code>length</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
-<li><a name="advise.advice"><a href="#advice"><code>advice</code></a></a>: <a href="#advice"><a href="#advice"><code>advice</code></a></a></li>
+<li><a name="method_descriptor.advise.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.advise.offset"><code>offset</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+<li><a name="method_descriptor.advise.length"><code>length</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+<li><a name="method_descriptor.advise.advice"><a href="#advice"><code>advice</code></a></a>: <a href="#advice"><a href="#advice"><code>advice</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="advise.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.advise.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="sync_data"><code>sync-data: func</code></a></h4>
+<h4><a name="method_descriptor.sync_data"><code>[method]descriptor.sync-data: func</code></a></h4>
 <p>Synchronize the data of a file to disk.</p>
 <p>This function succeeds with no effect if the file descriptor is not
 opened for writing.</p>
 <p>Note: This is similar to <code>fdatasync</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="sync_data.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a name="method_descriptor.sync_data.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="sync_data.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.sync_data.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="get_flags"><code>get-flags: func</code></a></h4>
+<h4><a name="method_descriptor.get_flags"><code>[method]descriptor.get-flags: func</code></a></h4>
 <p>Get flags associated with a descriptor.</p>
 <p>Note: This returns similar flags to <code>fcntl(fd, F_GETFL)</code> in POSIX.</p>
 <p>Note: This returns the value that was the <code>fs_flags</code> value returned
 from <code>fdstat_get</code> in earlier versions of WASI.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="get_flags.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a name="method_descriptor.get_flags.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="get_flags.0"></a> result&lt;<a href="#descriptor_flags"><a href="#descriptor_flags"><code>descriptor-flags</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.get_flags.0"></a> result&lt;<a href="#descriptor_flags"><a href="#descriptor_flags"><code>descriptor-flags</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="get_type"><code>get-type: func</code></a></h4>
+<h4><a name="method_descriptor.get_type"><code>[method]descriptor.get-type: func</code></a></h4>
 <p>Get the dynamic type of a descriptor.</p>
 <p>Note: This returns the same value as the <code>type</code> field of the <code>fd-stat</code>
-returned by <a href="#stat"><code>stat</code></a>, <a href="#stat_at"><code>stat-at</code></a> and similar.</p>
+returned by <code>stat</code>, <code>stat-at</code> and similar.</p>
 <p>Note: This returns similar flags to the <code>st_mode &amp; S_IFMT</code> value provided
 by <code>fstat</code> in POSIX.</p>
 <p>Note: This returns the value that was the <code>fs_filetype</code> value returned
 from <code>fdstat_get</code> in earlier versions of WASI.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="get_type.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a name="method_descriptor.get_type.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="get_type.0"></a> result&lt;<a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.get_type.0"></a> result&lt;<a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_flags"><code>set-flags: func</code></a></h4>
+<h4><a name="method_descriptor.set_flags"><code>[method]descriptor.set-flags: func</code></a></h4>
 <p>Set status flags associated with a descriptor.</p>
 <p>This function may only change the <code>non-blocking</code> flag.</p>
 <p>Note: This is similar to <code>fcntl(fd, F_SETFL, flags)</code> in POSIX.</p>
 <p>Note: This was called <code>fd_fdstat_set_flags</code> in earlier versions of WASI.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="set_flags.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="set_flags.flags"><code>flags</code></a>: <a href="#descriptor_flags"><a href="#descriptor_flags"><code>descriptor-flags</code></a></a></li>
+<li><a name="method_descriptor.set_flags.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.set_flags.flags"><code>flags</code></a>: <a href="#descriptor_flags"><a href="#descriptor_flags"><code>descriptor-flags</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_flags.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.set_flags.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_size"><code>set-size: func</code></a></h4>
+<h4><a name="method_descriptor.set_size"><code>[method]descriptor.set-size: func</code></a></h4>
 <p>Adjust the size of an open file. If this increases the file's size, the
 extra bytes are filled with zeros.</p>
 <p>Note: This was called <code>fd_filestat_set_size</code> in earlier versions of WASI.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="set_size.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="set_size.size"><code>size</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+<li><a name="method_descriptor.set_size.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.set_size.size"><code>size</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.set_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_times"><code>set-times: func</code></a></h4>
+<h4><a name="method_descriptor.set_times"><code>[method]descriptor.set-times: func</code></a></h4>
 <p>Adjust the timestamps of an open file or directory.</p>
 <p>Note: This is similar to <code>futimens</code> in POSIX.</p>
 <p>Note: This was called <code>fd_filestat_set_times</code> in earlier versions of WASI.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="set_times.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="set_times.data_access_timestamp"><code>data-access-timestamp</code></a>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
-<li><a name="set_times.data_modification_timestamp"><code>data-modification-timestamp</code></a>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
+<li><a name="method_descriptor.set_times.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.set_times.data_access_timestamp"><code>data-access-timestamp</code></a>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
+<li><a name="method_descriptor.set_times.data_modification_timestamp"><code>data-modification-timestamp</code></a>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_times.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.set_times.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="read"><code>read: func</code></a></h4>
+<h4><a name="method_descriptor.read"><code>[method]descriptor.read: func</code></a></h4>
 <p>Read from a descriptor, without using and updating the descriptor's offset.</p>
 <p>This function returns a list of bytes containing the data that was
 read, along with a bool which, when true, indicates that the end of the
@@ -1127,15 +1076,15 @@ if the I/O operation is interrupted.</p>
 <p>Note: This is similar to <code>pread</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="read.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="read.length"><code>length</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
-<li><a name="read.offset"><code>offset</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+<li><a name="method_descriptor.read.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.read.length"><code>length</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+<li><a name="method_descriptor.read.offset"><code>offset</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <code>bool</code>), <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <code>bool</code>), <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="write"><code>write: func</code></a></h4>
+<h4><a name="method_descriptor.write"><code>[method]descriptor.write: func</code></a></h4>
 <p>Write to a descriptor, without using and updating the descriptor's offset.</p>
 <p>It is valid to write past the end of a file; the file is extended to the
 extent of the write, with bytes between the previous end and the start of
@@ -1144,15 +1093,15 @@ the write set to zero.</p>
 <p>Note: This is similar to <code>pwrite</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="write.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="write.buffer"><code>buffer</code></a>: list&lt;<code>u8</code>&gt;</li>
-<li><a name="write.offset"><code>offset</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+<li><a name="method_descriptor.write.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.write.buffer"><code>buffer</code></a>: list&lt;<code>u8</code>&gt;</li>
+<li><a name="method_descriptor.write.offset"><code>offset</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="write.0"></a> result&lt;<a href="#filesize"><a href="#filesize"><code>filesize</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.write.0"></a> result&lt;<a href="#filesize"><a href="#filesize"><code>filesize</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="read_directory"><code>read-directory: func</code></a></h4>
+<h4><a name="method_descriptor.read_directory"><code>[method]descriptor.read-directory: func</code></a></h4>
 <p>Read directory entries from a directory.</p>
 <p>On filesystems where directories contain entries referring to themselves
 and their parents, often named <code>.</code> and <code>..</code> respectively, these entries
@@ -1162,96 +1111,96 @@ directory. Multiple streams may be active on the same directory, and they
 do not interfere with each other.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="read_directory.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a name="method_descriptor.read_directory.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="read_directory.0"></a> result&lt;<a href="#directory_entry_stream"><a href="#directory_entry_stream"><code>directory-entry-stream</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.read_directory.0"></a> result&lt;own&lt;<a href="#directory_entry_stream"><a href="#directory_entry_stream"><code>directory-entry-stream</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="sync"><code>sync: func</code></a></h4>
+<h4><a name="method_descriptor.sync"><code>[method]descriptor.sync: func</code></a></h4>
 <p>Synchronize the data and metadata of a file to disk.</p>
 <p>This function succeeds with no effect if the file descriptor is not
 opened for writing.</p>
 <p>Note: This is similar to <code>fsync</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="sync.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a name="method_descriptor.sync.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="sync.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.sync.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="create_directory_at"><code>create-directory-at: func</code></a></h4>
+<h4><a name="method_descriptor.create_directory_at"><code>[method]descriptor.create-directory-at: func</code></a></h4>
 <p>Create a directory.</p>
 <p>Note: This is similar to <code>mkdirat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="create_directory_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="create_directory_at.path"><code>path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.create_directory_at.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.create_directory_at.path"><code>path</code></a>: <code>string</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="create_directory_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.create_directory_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="stat"><code>stat: func</code></a></h4>
+<h4><a name="method_descriptor.stat"><code>[method]descriptor.stat: func</code></a></h4>
 <p>Return the attributes of an open file or directory.</p>
 <p>Note: This is similar to <code>fstat</code> in POSIX.</p>
 <p>Note: This was called <code>fd_filestat_get</code> in earlier versions of WASI.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="stat.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a name="method_descriptor.stat.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="stat.0"></a> result&lt;<a href="#descriptor_stat"><a href="#descriptor_stat"><code>descriptor-stat</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.stat.0"></a> result&lt;<a href="#descriptor_stat"><a href="#descriptor_stat"><code>descriptor-stat</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="stat_at"><code>stat-at: func</code></a></h4>
+<h4><a name="method_descriptor.stat_at"><code>[method]descriptor.stat-at: func</code></a></h4>
 <p>Return the attributes of a file or directory.</p>
 <p>Note: This is similar to <code>fstatat</code> in POSIX.</p>
 <p>Note: This was called <code>path_filestat_get</code> in earlier versions of WASI.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="stat_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="stat_at.path_flags"><a href="#path_flags"><code>path-flags</code></a></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
-<li><a name="stat_at.path"><code>path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.stat_at.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.stat_at.path_flags"><a href="#path_flags"><code>path-flags</code></a></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
+<li><a name="method_descriptor.stat_at.path"><code>path</code></a>: <code>string</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="stat_at.0"></a> result&lt;<a href="#descriptor_stat"><a href="#descriptor_stat"><code>descriptor-stat</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.stat_at.0"></a> result&lt;<a href="#descriptor_stat"><a href="#descriptor_stat"><code>descriptor-stat</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_times_at"><code>set-times-at: func</code></a></h4>
+<h4><a name="method_descriptor.set_times_at"><code>[method]descriptor.set-times-at: func</code></a></h4>
 <p>Adjust the timestamps of a file or directory.</p>
 <p>Note: This is similar to <code>utimensat</code> in POSIX.</p>
 <p>Note: This was called <code>path_filestat_set_times</code> in earlier versions of
 WASI.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="set_times_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="set_times_at.path_flags"><a href="#path_flags"><code>path-flags</code></a></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
-<li><a name="set_times_at.path"><code>path</code></a>: <code>string</code></li>
-<li><a name="set_times_at.data_access_timestamp"><code>data-access-timestamp</code></a>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
-<li><a name="set_times_at.data_modification_timestamp"><code>data-modification-timestamp</code></a>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
+<li><a name="method_descriptor.set_times_at.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.set_times_at.path_flags"><a href="#path_flags"><code>path-flags</code></a></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
+<li><a name="method_descriptor.set_times_at.path"><code>path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.set_times_at.data_access_timestamp"><code>data-access-timestamp</code></a>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
+<li><a name="method_descriptor.set_times_at.data_modification_timestamp"><code>data-modification-timestamp</code></a>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_times_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.set_times_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="link_at"><code>link-at: func</code></a></h4>
+<h4><a name="method_descriptor.link_at"><code>[method]descriptor.link-at: func</code></a></h4>
 <p>Create a hard link.</p>
 <p>Note: This is similar to <code>linkat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="link_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="link_at.old_path_flags"><code>old-path-flags</code></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
-<li><a name="link_at.old_path"><code>old-path</code></a>: <code>string</code></li>
-<li><a name="link_at.new_descriptor"><code>new-descriptor</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="link_at.new_path"><code>new-path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.link_at.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.link_at.old_path_flags"><code>old-path-flags</code></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
+<li><a name="method_descriptor.link_at.old_path"><code>old-path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.link_at.new_descriptor"><code>new-descriptor</code></a>: own&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.link_at.new_path"><code>new-path</code></a>: <code>string</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="link_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.link_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="open_at"><code>open-at: func</code></a></h4>
+<h4><a name="method_descriptor.open_at"><code>[method]descriptor.open-at: func</code></a></h4>
 <p>Open a file or directory.</p>
 <p>The returned descriptor is not guaranteed to be the lowest-numbered
 descriptor not currently open/ it is randomized to prevent applications
@@ -1260,82 +1209,82 @@ error-prone in multi-threaded contexts. The returned descriptor is
 guaranteed to be less than 2**31.</p>
 <p>If <code>flags</code> contains <a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a>, and the base
 descriptor doesn't have <a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a> set,
-<a href="#open_at"><code>open-at</code></a> fails with <a href="#error_code.read_only"><code>error-code::read-only</code></a>.</p>
-<p>If <code>flags</code> contains <a href="#write"><code>write</code></a> or <code>mutate-directory</code>, or <a href="#open_flags"><code>open-flags</code></a>
+<code>open-at</code> fails with <a href="#error_code.read_only"><code>error-code::read-only</code></a>.</p>
+<p>If <code>flags</code> contains <code>write</code> or <code>mutate-directory</code>, or <a href="#open_flags"><code>open-flags</code></a>
 contains <code>truncate</code> or <code>create</code>, and the base descriptor doesn't have
-<a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a> set, <a href="#open_at"><code>open-at</code></a> fails with
+<a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a> set, <code>open-at</code> fails with
 <a href="#error_code.read_only"><code>error-code::read-only</code></a>.</p>
 <p>Note: This is similar to <code>openat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="open_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="open_at.path_flags"><a href="#path_flags"><code>path-flags</code></a></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
-<li><a name="open_at.path"><code>path</code></a>: <code>string</code></li>
-<li><a name="open_at.open_flags"><a href="#open_flags"><code>open-flags</code></a></a>: <a href="#open_flags"><a href="#open_flags"><code>open-flags</code></a></a></li>
-<li><a name="open_at.flags"><code>flags</code></a>: <a href="#descriptor_flags"><a href="#descriptor_flags"><code>descriptor-flags</code></a></a></li>
-<li><a name="open_at.modes"><a href="#modes"><code>modes</code></a></a>: <a href="#modes"><a href="#modes"><code>modes</code></a></a></li>
+<li><a name="method_descriptor.open_at.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.open_at.path_flags"><a href="#path_flags"><code>path-flags</code></a></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
+<li><a name="method_descriptor.open_at.path"><code>path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.open_at.open_flags"><a href="#open_flags"><code>open-flags</code></a></a>: <a href="#open_flags"><a href="#open_flags"><code>open-flags</code></a></a></li>
+<li><a name="method_descriptor.open_at.flags"><code>flags</code></a>: <a href="#descriptor_flags"><a href="#descriptor_flags"><code>descriptor-flags</code></a></a></li>
+<li><a name="method_descriptor.open_at.modes"><a href="#modes"><code>modes</code></a></a>: <a href="#modes"><a href="#modes"><code>modes</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="open_at.0"></a> result&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.open_at.0"></a> result&lt;own&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="readlink_at"><code>readlink-at: func</code></a></h4>
+<h4><a name="method_descriptor.readlink_at"><code>[method]descriptor.readlink-at: func</code></a></h4>
 <p>Read the contents of a symbolic link.</p>
 <p>If the contents contain an absolute or rooted path in the underlying
 filesystem, this function fails with <a href="#error_code.not_permitted"><code>error-code::not-permitted</code></a>.</p>
 <p>Note: This is similar to <code>readlinkat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="readlink_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="readlink_at.path"><code>path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.readlink_at.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.readlink_at.path"><code>path</code></a>: <code>string</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="readlink_at.0"></a> result&lt;<code>string</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.readlink_at.0"></a> result&lt;<code>string</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="remove_directory_at"><code>remove-directory-at: func</code></a></h4>
+<h4><a name="method_descriptor.remove_directory_at"><code>[method]descriptor.remove-directory-at: func</code></a></h4>
 <p>Remove a directory.</p>
 <p>Return <a href="#error_code.not_empty"><code>error-code::not-empty</code></a> if the directory is not empty.</p>
 <p>Note: This is similar to <code>unlinkat(fd, path, AT_REMOVEDIR)</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="remove_directory_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="remove_directory_at.path"><code>path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.remove_directory_at.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.remove_directory_at.path"><code>path</code></a>: <code>string</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="remove_directory_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.remove_directory_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="rename_at"><code>rename-at: func</code></a></h4>
+<h4><a name="method_descriptor.rename_at"><code>[method]descriptor.rename-at: func</code></a></h4>
 <p>Rename a filesystem object.</p>
 <p>Note: This is similar to <code>renameat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="rename_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="rename_at.old_path"><code>old-path</code></a>: <code>string</code></li>
-<li><a name="rename_at.new_descriptor"><code>new-descriptor</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="rename_at.new_path"><code>new-path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.rename_at.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.rename_at.old_path"><code>old-path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.rename_at.new_descriptor"><code>new-descriptor</code></a>: own&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.rename_at.new_path"><code>new-path</code></a>: <code>string</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="rename_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.rename_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="symlink_at"><code>symlink-at: func</code></a></h4>
+<h4><a name="method_descriptor.symlink_at"><code>[method]descriptor.symlink-at: func</code></a></h4>
 <p>Create a symbolic link (also known as a &quot;symlink&quot;).</p>
 <p>If <code>old-path</code> starts with <code>/</code>, the function fails with
 <a href="#error_code.not_permitted"><code>error-code::not-permitted</code></a>.</p>
 <p>Note: This is similar to <code>symlinkat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="symlink_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="symlink_at.old_path"><code>old-path</code></a>: <code>string</code></li>
-<li><a name="symlink_at.new_path"><code>new-path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.symlink_at.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.symlink_at.old_path"><code>old-path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.symlink_at.new_path"><code>new-path</code></a>: <code>string</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="symlink_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.symlink_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="access_at"><code>access-at: func</code></a></h4>
+<h4><a name="method_descriptor.access_at"><code>[method]descriptor.access-at: func</code></a></h4>
 <p>Check accessibility of a filesystem path.</p>
 <p>Check whether the given filesystem path names an object which is
 readable, writable, or executable, or whether it exists.</p>
@@ -1345,64 +1294,64 @@ entities.</p>
 <p>Note: This is similar to <code>faccessat</code> with the <code>AT_EACCESS</code> flag in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="access_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="access_at.path_flags"><a href="#path_flags"><code>path-flags</code></a></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
-<li><a name="access_at.path"><code>path</code></a>: <code>string</code></li>
-<li><a name="access_at.type"><code>type</code></a>: <a href="#access_type"><a href="#access_type"><code>access-type</code></a></a></li>
+<li><a name="method_descriptor.access_at.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.access_at.path_flags"><a href="#path_flags"><code>path-flags</code></a></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
+<li><a name="method_descriptor.access_at.path"><code>path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.access_at.type"><code>type</code></a>: <a href="#access_type"><a href="#access_type"><code>access-type</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="access_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.access_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="unlink_file_at"><code>unlink-file-at: func</code></a></h4>
+<h4><a name="method_descriptor.unlink_file_at"><code>[method]descriptor.unlink-file-at: func</code></a></h4>
 <p>Unlink a filesystem object that is not a directory.</p>
 <p>Return <a href="#error_code.is_directory"><code>error-code::is-directory</code></a> if the path refers to a directory.
 Note: This is similar to <code>unlinkat(fd, path, 0)</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="unlink_file_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="unlink_file_at.path"><code>path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.unlink_file_at.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.unlink_file_at.path"><code>path</code></a>: <code>string</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="unlink_file_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.unlink_file_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="change_file_permissions_at"><code>change-file-permissions-at: func</code></a></h4>
+<h4><a name="method_descriptor.change_file_permissions_at"><code>[method]descriptor.change-file-permissions-at: func</code></a></h4>
 <p>Change the permissions of a filesystem object that is not a directory.</p>
 <p>Note that the ultimate meanings of these permissions is
 filesystem-specific.</p>
 <p>Note: This is similar to <code>fchmodat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="change_file_permissions_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="change_file_permissions_at.path_flags"><a href="#path_flags"><code>path-flags</code></a></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
-<li><a name="change_file_permissions_at.path"><code>path</code></a>: <code>string</code></li>
-<li><a name="change_file_permissions_at.modes"><a href="#modes"><code>modes</code></a></a>: <a href="#modes"><a href="#modes"><code>modes</code></a></a></li>
+<li><a name="method_descriptor.change_file_permissions_at.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.change_file_permissions_at.path_flags"><a href="#path_flags"><code>path-flags</code></a></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
+<li><a name="method_descriptor.change_file_permissions_at.path"><code>path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.change_file_permissions_at.modes"><a href="#modes"><code>modes</code></a></a>: <a href="#modes"><a href="#modes"><code>modes</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="change_file_permissions_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.change_file_permissions_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="change_directory_permissions_at"><code>change-directory-permissions-at: func</code></a></h4>
+<h4><a name="method_descriptor.change_directory_permissions_at"><code>[method]descriptor.change-directory-permissions-at: func</code></a></h4>
 <p>Change the permissions of a directory.</p>
 <p>Note that the ultimate meanings of these permissions is
 filesystem-specific.</p>
 <p>Unlike in POSIX, the <code>executable</code> flag is not reinterpreted as a &quot;search&quot;
-flag. <a href="#read"><code>read</code></a> on a directory implies readability and searchability, and
+flag. <code>read</code> on a directory implies readability and searchability, and
 <code>execute</code> is not valid for directories.</p>
 <p>Note: This is similar to <code>fchmodat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="change_directory_permissions_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="change_directory_permissions_at.path_flags"><a href="#path_flags"><code>path-flags</code></a></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
-<li><a name="change_directory_permissions_at.path"><code>path</code></a>: <code>string</code></li>
-<li><a name="change_directory_permissions_at.modes"><a href="#modes"><code>modes</code></a></a>: <a href="#modes"><a href="#modes"><code>modes</code></a></a></li>
+<li><a name="method_descriptor.change_directory_permissions_at.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
+<li><a name="method_descriptor.change_directory_permissions_at.path_flags"><a href="#path_flags"><code>path-flags</code></a></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
+<li><a name="method_descriptor.change_directory_permissions_at.path"><code>path</code></a>: <code>string</code></li>
+<li><a name="method_descriptor.change_directory_permissions_at.modes"><a href="#modes"><code>modes</code></a></a>: <a href="#modes"><a href="#modes"><code>modes</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="change_directory_permissions_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.change_directory_permissions_at.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="lock_shared"><code>lock-shared: func</code></a></h4>
+<h4><a name="method_descriptor.lock_shared"><code>[method]descriptor.lock-shared: func</code></a></h4>
 <p>Request a shared advisory lock for an open file.</p>
 <p>This requests a <em>shared</em> lock; more than one shared lock can be held for
 a file at the same time.</p>
@@ -1418,13 +1367,13 @@ locking, this function returns <a href="#error_code.unsupported"><code>error-cod
 <p>Note: This is similar to <code>flock(fd, LOCK_SH)</code> in Unix.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="lock_shared.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a name="method_descriptor.lock_shared.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="lock_shared.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.lock_shared.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="lock_exclusive"><code>lock-exclusive: func</code></a></h4>
+<h4><a name="method_descriptor.lock_exclusive"><code>[method]descriptor.lock-exclusive: func</code></a></h4>
 <p>Request an exclusive advisory lock for an open file.</p>
 <p>This requests an <em>exclusive</em> lock; no other locks may be held for the
 file while an exclusive lock is held.</p>
@@ -1442,13 +1391,13 @@ locking, this function returns <a href="#error_code.unsupported"><code>error-cod
 <p>Note: This is similar to <code>flock(fd, LOCK_EX)</code> in Unix.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="lock_exclusive.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a name="method_descriptor.lock_exclusive.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="lock_exclusive.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.lock_exclusive.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="try_lock_shared"><code>try-lock-shared: func</code></a></h4>
+<h4><a name="method_descriptor.try_lock_shared"><code>[method]descriptor.try-lock-shared: func</code></a></h4>
 <p>Request a shared advisory lock for an open file.</p>
 <p>This requests a <em>shared</em> lock; more than one shared lock can be held for
 a file at the same time.</p>
@@ -1465,13 +1414,13 @@ locking, this function returns <a href="#error_code.unsupported"><code>error-cod
 <p>Note: This is similar to <code>flock(fd, LOCK_SH | LOCK_NB)</code> in Unix.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="try_lock_shared.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a name="method_descriptor.try_lock_shared.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="try_lock_shared.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.try_lock_shared.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="try_lock_exclusive"><code>try-lock-exclusive: func</code></a></h4>
+<h4><a name="method_descriptor.try_lock_exclusive"><code>[method]descriptor.try-lock-exclusive: func</code></a></h4>
 <p>Request an exclusive advisory lock for an open file.</p>
 <p>This requests an <em>exclusive</em> lock; no other locks may be held for the
 file while an exclusive lock is held.</p>
@@ -1490,114 +1439,39 @@ locking, this function returns <a href="#error_code.unsupported"><code>error-cod
 <p>Note: This is similar to <code>flock(fd, LOCK_EX | LOCK_NB)</code> in Unix.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="try_lock_exclusive.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a name="method_descriptor.try_lock_exclusive.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="try_lock_exclusive.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.try_lock_exclusive.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="unlock"><code>unlock: func</code></a></h4>
+<h4><a name="method_descriptor.unlock"><code>[method]descriptor.unlock: func</code></a></h4>
 <p>Release a shared or exclusive lock on an open file.</p>
 <p>Note: This is similar to <code>flock(fd, LOCK_UN)</code> in Unix.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="unlock.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a name="method_descriptor.unlock.self"><code>self</code></a>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="unlock.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_descriptor.unlock.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="drop_descriptor"><code>drop-descriptor: func</code></a></h4>
-<p>Dispose of the specified <a href="#descriptor"><code>descriptor</code></a>, after which it may no longer
-be used.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="drop_descriptor.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-</ul>
-<h4><a name="read_directory_entry"><code>read-directory-entry: func</code></a></h4>
+<h4><a name="method_directory_entry_stream.read_directory_entry"><code>[method]directory-entry-stream.read-directory-entry: func</code></a></h4>
 <p>Read a single directory entry from a <a href="#directory_entry_stream"><code>directory-entry-stream</code></a>.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="read_directory_entry.this"><code>this</code></a>: <a href="#directory_entry_stream"><a href="#directory_entry_stream"><code>directory-entry-stream</code></a></a></li>
+<li><a name="method_directory_entry_stream.read_directory_entry.self"><code>self</code></a>: borrow&lt;<a href="#directory_entry_stream"><a href="#directory_entry_stream"><code>directory-entry-stream</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="read_directory_entry.0"></a> result&lt;option&lt;<a href="#directory_entry"><a href="#directory_entry"><code>directory-entry</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
-</ul>
-<h4><a name="drop_directory_entry_stream"><code>drop-directory-entry-stream: func</code></a></h4>
-<p>Dispose of the specified <a href="#directory_entry_stream"><code>directory-entry-stream</code></a>, after which it may no longer
-be used.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="drop_directory_entry_stream.this"><code>this</code></a>: <a href="#directory_entry_stream"><a href="#directory_entry_stream"><code>directory-entry-stream</code></a></a></li>
+<li><a name="method_directory_entry_stream.read_directory_entry.0"></a> result&lt;option&lt;<a href="#directory_entry"><a href="#directory_entry"><code>directory-entry</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:sockets_network">Import interface wasi:sockets/network</a></h2>
 <hr />
 <h3>Types</h3>
-<h4><a name="network"><code>type network</code></a></h4>
-<p><code>u32</code></p>
-<p>An opaque resource that represents access to (a subset of) the network.
-This enables context-based security for networking.
-There is no need for this to map 1:1 to a physical network interface.
-<p>FYI, In the future this will be replaced by handle types.</p>
-<h4><a name="ipv6_address"><code>tuple ipv6-address</code></a></h4>
-<h5>Tuple Fields</h5>
-<ul>
-<li><a name="ipv6_address.0"><code>0</code></a>: <code>u16</code></li>
-<li><a name="ipv6_address.1"><code>1</code></a>: <code>u16</code></li>
-<li><a name="ipv6_address.2"><code>2</code></a>: <code>u16</code></li>
-<li><a name="ipv6_address.3"><code>3</code></a>: <code>u16</code></li>
-<li><a name="ipv6_address.4"><code>4</code></a>: <code>u16</code></li>
-<li><a name="ipv6_address.5"><code>5</code></a>: <code>u16</code></li>
-<li><a name="ipv6_address.6"><code>6</code></a>: <code>u16</code></li>
-<li><a name="ipv6_address.7"><code>7</code></a>: <code>u16</code></li>
-</ul>
-<h4><a name="ipv6_socket_address"><code>record ipv6-socket-address</code></a></h4>
-<h5>Record Fields</h5>
-<ul>
-<li><a name="ipv6_socket_address.port"><code>port</code></a>: <code>u16</code></li>
-<li><a name="ipv6_socket_address.flow_info"><code>flow-info</code></a>: <code>u32</code></li>
-<li><a name="ipv6_socket_address.address"><code>address</code></a>: <a href="#ipv6_address"><a href="#ipv6_address"><code>ipv6-address</code></a></a></li>
-<li><a name="ipv6_socket_address.scope_id"><code>scope-id</code></a>: <code>u32</code></li>
-</ul>
-<h4><a name="ipv4_address"><code>tuple ipv4-address</code></a></h4>
-<h5>Tuple Fields</h5>
-<ul>
-<li><a name="ipv4_address.0"><code>0</code></a>: <code>u8</code></li>
-<li><a name="ipv4_address.1"><code>1</code></a>: <code>u8</code></li>
-<li><a name="ipv4_address.2"><code>2</code></a>: <code>u8</code></li>
-<li><a name="ipv4_address.3"><code>3</code></a>: <code>u8</code></li>
-</ul>
-<h4><a name="ipv4_socket_address"><code>record ipv4-socket-address</code></a></h4>
-<h5>Record Fields</h5>
-<ul>
-<li><a name="ipv4_socket_address.port"><code>port</code></a>: <code>u16</code></li>
-<li><a name="ipv4_socket_address.address"><code>address</code></a>: <a href="#ipv4_address"><a href="#ipv4_address"><code>ipv4-address</code></a></a></li>
-</ul>
-<h4><a name="ip_socket_address"><code>variant ip-socket-address</code></a></h4>
-<h5>Variant Cases</h5>
-<ul>
-<li><a name="ip_socket_address.ipv4"><code>ipv4</code></a>: <a href="#ipv4_socket_address"><a href="#ipv4_socket_address"><code>ipv4-socket-address</code></a></a></li>
-<li><a name="ip_socket_address.ipv6"><code>ipv6</code></a>: <a href="#ipv6_socket_address"><a href="#ipv6_socket_address"><code>ipv6-socket-address</code></a></a></li>
-</ul>
-<h4><a name="ip_address_family"><code>enum ip-address-family</code></a></h4>
-<h5>Enum Cases</h5>
-<ul>
-<li>
-<p><a name="ip_address_family.ipv4"><code>ipv4</code></a></p>
-<p>Similar to `AF_INET` in POSIX.
-</li>
-<li>
-<p><a name="ip_address_family.ipv6"><code>ipv6</code></a></p>
-<p>Similar to `AF_INET6` in POSIX.
-</li>
-</ul>
-<h4><a name="ip_address"><code>variant ip-address</code></a></h4>
-<h5>Variant Cases</h5>
-<ul>
-<li><a name="ip_address.ipv4"><code>ipv4</code></a>: <a href="#ipv4_address"><a href="#ipv4_address"><code>ipv4-address</code></a></a></li>
-<li><a name="ip_address.ipv6"><code>ipv6</code></a>: <a href="#ipv6_address"><a href="#ipv6_address"><code>ipv6-address</code></a></a></li>
-</ul>
+<h4><a name="network"><code>resource network</code></a></h4>
+<h5>Resource Members</h5>
+<p>TODO</p>
 <h4><a name="error_code"><code>enum error-code</code></a></h4>
 <p>Error codes.</p>
 <p>In theory, every API can return any error code.
@@ -1747,14 +1621,63 @@ combined with a couple of errors that are always possible:</p>
 <p>A permanent failure in name resolution occurred.
 </li>
 </ul>
-<hr />
-<h3>Functions</h3>
-<h4><a name="drop_network"><code>drop-network: func</code></a></h4>
-<p>Dispose of the specified <a href="#network"><code>network</code></a>, after which it may no longer be used.</p>
-<p>Note: this function is scheduled to be removed when Resources are natively supported in Wit.</p>
-<h5>Params</h5>
+<h4><a name="ip_address_family"><code>enum ip-address-family</code></a></h4>
+<h5>Enum Cases</h5>
 <ul>
-<li><a name="drop_network.this"><code>this</code></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
+<li>
+<p><a name="ip_address_family.ipv4"><code>ipv4</code></a></p>
+<p>Similar to `AF_INET` in POSIX.
+</li>
+<li>
+<p><a name="ip_address_family.ipv6"><code>ipv6</code></a></p>
+<p>Similar to `AF_INET6` in POSIX.
+</li>
+</ul>
+<h4><a name="ipv4_address"><code>tuple ipv4-address</code></a></h4>
+<h5>Tuple Fields</h5>
+<ul>
+<li><a name="ipv4_address.0"><code>0</code></a>: <code>u8</code></li>
+<li><a name="ipv4_address.1"><code>1</code></a>: <code>u8</code></li>
+<li><a name="ipv4_address.2"><code>2</code></a>: <code>u8</code></li>
+<li><a name="ipv4_address.3"><code>3</code></a>: <code>u8</code></li>
+</ul>
+<h4><a name="ipv6_address"><code>tuple ipv6-address</code></a></h4>
+<h5>Tuple Fields</h5>
+<ul>
+<li><a name="ipv6_address.0"><code>0</code></a>: <code>u16</code></li>
+<li><a name="ipv6_address.1"><code>1</code></a>: <code>u16</code></li>
+<li><a name="ipv6_address.2"><code>2</code></a>: <code>u16</code></li>
+<li><a name="ipv6_address.3"><code>3</code></a>: <code>u16</code></li>
+<li><a name="ipv6_address.4"><code>4</code></a>: <code>u16</code></li>
+<li><a name="ipv6_address.5"><code>5</code></a>: <code>u16</code></li>
+<li><a name="ipv6_address.6"><code>6</code></a>: <code>u16</code></li>
+<li><a name="ipv6_address.7"><code>7</code></a>: <code>u16</code></li>
+</ul>
+<h4><a name="ip_address"><code>variant ip-address</code></a></h4>
+<h5>Variant Cases</h5>
+<ul>
+<li><a name="ip_address.ipv4"><code>ipv4</code></a>: <a href="#ipv4_address"><a href="#ipv4_address"><code>ipv4-address</code></a></a></li>
+<li><a name="ip_address.ipv6"><code>ipv6</code></a>: <a href="#ipv6_address"><a href="#ipv6_address"><code>ipv6-address</code></a></a></li>
+</ul>
+<h4><a name="ipv4_socket_address"><code>record ipv4-socket-address</code></a></h4>
+<h5>Record Fields</h5>
+<ul>
+<li><a name="ipv4_socket_address.port"><code>port</code></a>: <code>u16</code></li>
+<li><a name="ipv4_socket_address.address"><code>address</code></a>: <a href="#ipv4_address"><a href="#ipv4_address"><code>ipv4-address</code></a></a></li>
+</ul>
+<h4><a name="ipv6_socket_address"><code>record ipv6-socket-address</code></a></h4>
+<h5>Record Fields</h5>
+<ul>
+<li><a name="ipv6_socket_address.port"><code>port</code></a>: <code>u16</code></li>
+<li><a name="ipv6_socket_address.flow_info"><code>flow-info</code></a>: <code>u32</code></li>
+<li><a name="ipv6_socket_address.address"><code>address</code></a>: <a href="#ipv6_address"><a href="#ipv6_address"><code>ipv6-address</code></a></a></li>
+<li><a name="ipv6_socket_address.scope_id"><code>scope-id</code></a>: <code>u32</code></li>
+</ul>
+<h4><a name="ip_socket_address"><code>variant ip-socket-address</code></a></h4>
+<h5>Variant Cases</h5>
+<ul>
+<li><a name="ip_socket_address.ipv4"><code>ipv4</code></a>: <a href="#ipv4_socket_address"><a href="#ipv4_socket_address"><code>ipv4-socket-address</code></a></a></li>
+<li><a name="ip_socket_address.ipv6"><code>ipv6</code></a>: <a href="#ipv6_socket_address"><a href="#ipv6_socket_address"><code>ipv6-socket-address</code></a></a></li>
 </ul>
 <h2><a name="wasi:sockets_instance_network">Import interface wasi:sockets/instance-network</a></h2>
 <p>This interface provides a value-export of the default network handle..</p>
@@ -1769,7 +1692,7 @@ combined with a couple of errors that are always possible:</p>
 <p>Get a handle to the default network.</p>
 <h5>Return values</h5>
 <ul>
-<li><a name="instance_network.0"></a> <a href="#network"><a href="#network"><code>network</code></a></a></li>
+<li><a name="instance_network.0"></a> own&lt;<a href="#network"><a href="#network"><code>network</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:sockets_ip_name_lookup">Import interface wasi:sockets/ip-name-lookup</a></h2>
 <hr />
@@ -1789,10 +1712,10 @@ combined with a couple of errors that are always possible:</p>
 #### <a name="ip_address_family">`type ip-address-family`</a>
 [`ip-address-family`](#ip_address_family)
 <p>
-#### <a name="resolve_address_stream">`type resolve-address-stream`</a>
-`u32`
-<p>
-----
+#### <a name="resolve_address_stream">`resource resolve-address-stream`</a>
+<h5>Resource Members</h5>
+<p>TODO</p>
+<hr />
 <h3>Functions</h3>
 <h4><a name="resolve_addresses"><code>resolve-addresses: func</code></a></h4>
 <p>Resolve an internet host name to a list of IP addresses.</p>
@@ -1801,7 +1724,7 @@ combined with a couple of errors that are always possible:</p>
 <ul>
 <li><code>name</code>: The name to look up. IP addresses are not allowed. Unicode domain names are automatically converted
 to ASCII using IDNA encoding.</li>
-<li><a href="#address_family"><code>address-family</code></a>: If provided, limit the results to addresses of this specific address family.</li>
+<li><code>address-family</code>: If provided, limit the results to addresses of this specific address family.</li>
 <li><code>include-unavailable</code>: When set to true, this function will also return addresses of which the runtime
 thinks (or knows) can't be connected to at the moment. For example, this will return IPv6 addresses on
 systems without an active IPv6 interface. Notes:</li>
@@ -1811,12 +1734,12 @@ systems without an active IPv6 interface. Notes:</li>
 <p>This function never blocks. It either immediately fails or immediately returns successfully with a <a href="#resolve_address_stream"><code>resolve-address-stream</code></a>
 that can be used to (asynchronously) fetch the results.</p>
 <p>At the moment, the stream never completes successfully with 0 items. Ie. the first call
-to <a href="#resolve_next_address"><code>resolve-next-address</code></a> never returns <code>ok(none)</code>. This may change in the future.</p>
+to <code>resolve-next-address</code> never returns <code>ok(none)</code>. This may change in the future.</p>
 <h1>Typical errors</h1>
 <ul>
 <li><code>invalid-name</code>:                 <code>name</code> is a syntactically invalid domain name.</li>
 <li><code>invalid-name</code>:                 <code>name</code> is an IP address.</li>
-<li><code>address-family-not-supported</code>: The specified <a href="#address_family"><code>address-family</code></a> is not supported. (EAI_FAMILY)</li>
+<li><code>address-family-not-supported</code>: The specified <code>address-family</code> is not supported. (EAI_FAMILY)</li>
 </ul>
 <h1>References:</h1>
 <ul>
@@ -1827,21 +1750,21 @@ to <a href="#resolve_next_address"><code>resolve-next-address</code></a> never r
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="resolve_addresses.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
+<li><a name="resolve_addresses.network"><a href="#network"><code>network</code></a></a>: own&lt;<a href="#network"><a href="#network"><code>network</code></a></a>&gt;</li>
 <li><a name="resolve_addresses.name"><code>name</code></a>: <code>string</code></li>
-<li><a name="resolve_addresses.address_family"><a href="#address_family"><code>address-family</code></a></a>: option&lt;<a href="#ip_address_family"><a href="#ip_address_family"><code>ip-address-family</code></a></a>&gt;</li>
+<li><a name="resolve_addresses.address_family"><code>address-family</code></a>: option&lt;<a href="#ip_address_family"><a href="#ip_address_family"><code>ip-address-family</code></a></a>&gt;</li>
 <li><a name="resolve_addresses.include_unavailable"><code>include-unavailable</code></a>: <code>bool</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="resolve_addresses.0"></a> result&lt;<a href="#resolve_address_stream"><a href="#resolve_address_stream"><code>resolve-address-stream</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="resolve_addresses.0"></a> result&lt;own&lt;<a href="#resolve_address_stream"><a href="#resolve_address_stream"><code>resolve-address-stream</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="resolve_next_address"><code>resolve-next-address: func</code></a></h4>
+<h4><a name="method_resolve_address_stream.resolve_next_address"><code>[method]resolve-address-stream.resolve-next-address: func</code></a></h4>
 <p>Returns the next address from the resolver.</p>
 <p>This function should be called multiple times. On each call, it will
 return the next address in connection order preference. If all
 addresses have been exhausted, this function returns <code>none</code>.
-After which, you should release the stream with <a href="#drop_resolve_address_stream"><code>drop-resolve-address-stream</code></a>.</p>
+After which, you should release the stream with <code>drop-resolve-address-stream</code>.</p>
 <p>This function never returns IPv4-mapped IPv6 addresses.</p>
 <h1>Typical errors</h1>
 <ul>
@@ -1852,30 +1775,23 @@ After which, you should release the stream with <a href="#drop_resolve_address_s
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="resolve_next_address.this"><code>this</code></a>: <a href="#resolve_address_stream"><a href="#resolve_address_stream"><code>resolve-address-stream</code></a></a></li>
+<li><a name="method_resolve_address_stream.resolve_next_address.self"><code>self</code></a>: borrow&lt;<a href="#resolve_address_stream"><a href="#resolve_address_stream"><code>resolve-address-stream</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="resolve_next_address.0"></a> result&lt;option&lt;<a href="#ip_address"><a href="#ip_address"><code>ip-address</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_resolve_address_stream.resolve_next_address.0"></a> result&lt;option&lt;<a href="#ip_address"><a href="#ip_address"><code>ip-address</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="drop_resolve_address_stream"><code>drop-resolve-address-stream: func</code></a></h4>
-<p>Dispose of the specified <a href="#resolve_address_stream"><code>resolve-address-stream</code></a>, after which it may no longer be used.</p>
-<p>Note: this function is scheduled to be removed when Resources are natively supported in Wit.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="drop_resolve_address_stream.this"><code>this</code></a>: <a href="#resolve_address_stream"><a href="#resolve_address_stream"><code>resolve-address-stream</code></a></a></li>
-</ul>
-<h4><a name="subscribe"><code>subscribe: func</code></a></h4>
+<h4><a name="method_resolve_address_stream.subscribe"><code>[method]resolve-address-stream.subscribe: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once the stream is ready for I/O.</p>
 <p>Note: this function is here for WASI Preview2 only.
 It's planned to be removed when <code>future</code> is natively supported in Preview3.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="subscribe.this"><code>this</code></a>: <a href="#resolve_address_stream"><a href="#resolve_address_stream"><code>resolve-address-stream</code></a></a></li>
+<li><a name="method_resolve_address_stream.subscribe.self"><code>self</code></a>: borrow&lt;<a href="#resolve_address_stream"><a href="#resolve_address_stream"><code>resolve-address-stream</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="subscribe.0"></a> <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
+<li><a name="method_resolve_address_stream.subscribe.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:sockets_tcp">Import interface wasi:sockets/tcp</a></h2>
 <hr />
@@ -1901,18 +1817,15 @@ It's planned to be removed when <code>future</code> is natively supported in Pre
 #### <a name="ip_address_family">`type ip-address-family`</a>
 [`ip-address-family`](#ip_address_family)
 <p>
-#### <a name="tcp_socket">`type tcp-socket`</a>
-`u32`
-<p>A TCP socket handle.
-<h4><a name="shutdown_type"><code>enum shutdown-type</code></a></h4>
+#### <a name="shutdown_type">`enum shutdown-type`</a>
 <h5>Enum Cases</h5>
 <ul>
 <li>
-<p><a name="shutdown_type.receive"><a href="#receive"><code>receive</code></a></a></p>
+<p><a name="shutdown_type.receive"><code>receive</code></a></p>
 <p>Similar to `SHUT_RD` in POSIX.
 </li>
 <li>
-<p><a name="shutdown_type.send"><a href="#send"><code>send</code></a></a></p>
+<p><a name="shutdown_type.send"><code>send</code></a></p>
 <p>Similar to `SHUT_WR` in POSIX.
 </li>
 <li>
@@ -1920,9 +1833,12 @@ It's planned to be removed when <code>future</code> is natively supported in Pre
 <p>Similar to `SHUT_RDWR` in POSIX.
 </li>
 </ul>
+<h4><a name="tcp_socket"><code>resource tcp-socket</code></a></h4>
+<h5>Resource Members</h5>
+<p>TODO</p>
 <hr />
 <h3>Functions</h3>
-<h4><a name="start_bind"><code>start-bind: func</code></a></h4>
+<h4><a name="method_tcp_socket.start_bind"><code>[method]tcp-socket.start-bind: func</code></a></h4>
 <p>Bind the socket to a specific network on the provided IP address and port.</p>
 <p>If the IP address is zero (<code>0.0.0.0</code> in IPv4, <code>::</code> in IPv6), it is left to the implementation to decide which
 network interface(s) to bind to.
@@ -1932,7 +1848,7 @@ implicitly bind the socket.</p>
 <p>Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.</p>
 <h1>Typical <code>start</code> errors</h1>
 <ul>
-<li><code>address-family-mismatch</code>:   The <a href="#local_address"><code>local-address</code></a> has the wrong address family. (EINVAL)</li>
+<li><code>address-family-mismatch</code>:   The <code>local-address</code> has the wrong address family. (EINVAL)</li>
 <li><code>already-bound</code>:             The socket is already bound. (EINVAL)</li>
 <li><code>concurrency-conflict</code>:      Another <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EALREADY)</li>
 </ul>
@@ -1940,7 +1856,7 @@ implicitly bind the socket.</p>
 <ul>
 <li><code>ephemeral-ports-exhausted</code>: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)</li>
 <li><code>address-in-use</code>:            Address is already in use. (EADDRINUSE)</li>
-<li><code>address-not-bindable</code>:      <a href="#local_address"><code>local-address</code></a> is not an address that the <a href="#network"><code>network</code></a> can bind to. (EADDRNOTAVAIL)</li>
+<li><code>address-not-bindable</code>:      <code>local-address</code> is not an address that the <a href="#network"><code>network</code></a> can bind to. (EADDRNOTAVAIL)</li>
 <li><code>not-in-progress</code>:           A <code>bind</code> operation is not in progress.</li>
 <li><code>would-block</code>:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)</li>
 </ul>
@@ -1953,24 +1869,24 @@ implicitly bind the socket.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="start_bind.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="start_bind.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
-<li><a name="start_bind.local_address"><a href="#local_address"><code>local-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
+<li><a name="method_tcp_socket.start_bind.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.start_bind.network"><a href="#network"><code>network</code></a></a>: own&lt;<a href="#network"><a href="#network"><code>network</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.start_bind.local_address"><code>local-address</code></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="start_bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.start_bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="finish_bind"><code>finish-bind: func</code></a></h4>
+<h4><a name="method_tcp_socket.finish_bind"><code>[method]tcp-socket.finish-bind: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="finish_bind.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.finish_bind.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="finish_bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.finish_bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="start_connect"><code>start-connect: func</code></a></h4>
+<h4><a name="method_tcp_socket.start_connect"><code>[method]tcp-socket.start-connect: func</code></a></h4>
 <p>Connect to a remote endpoint.</p>
 <p>On success:</p>
 <ul>
@@ -1979,9 +1895,9 @@ implicitly bind the socket.</p>
 </ul>
 <h1>Typical <code>start</code> errors</h1>
 <ul>
-<li><code>address-family-mismatch</code>:   The <a href="#remote_address"><code>remote-address</code></a> has the wrong address family. (EAFNOSUPPORT)</li>
-<li><code>invalid-remote-address</code>:    The IP address in <a href="#remote_address"><code>remote-address</code></a> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EADDRNOTAVAIL on Windows)</li>
-<li><code>invalid-remote-address</code>:    The port in <a href="#remote_address"><code>remote-address</code></a> is set to 0. (EADDRNOTAVAIL on Windows)</li>
+<li><code>address-family-mismatch</code>:   The <code>remote-address</code> has the wrong address family. (EAFNOSUPPORT)</li>
+<li><code>invalid-remote-address</code>:    The IP address in <code>remote-address</code> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EADDRNOTAVAIL on Windows)</li>
+<li><code>invalid-remote-address</code>:    The port in <code>remote-address</code> is set to 0. (EADDRNOTAVAIL on Windows)</li>
 <li><code>already-attached</code>:          The socket is already attached to a different network. The <a href="#network"><code>network</code></a> passed to <code>connect</code> must be identical to the one passed to <code>bind</code>.</li>
 <li><code>already-connected</code>:         The socket is already in the Connection state. (EISCONN)</li>
 <li><code>already-listening</code>:         The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)</li>
@@ -2006,24 +1922,24 @@ implicitly bind the socket.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="start_connect.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="start_connect.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
-<li><a name="start_connect.remote_address"><a href="#remote_address"><code>remote-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
+<li><a name="method_tcp_socket.start_connect.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.start_connect.network"><a href="#network"><code>network</code></a></a>: own&lt;<a href="#network"><a href="#network"><code>network</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.start_connect.remote_address"><code>remote-address</code></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="start_connect.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.start_connect.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="finish_connect"><code>finish-connect: func</code></a></h4>
+<h4><a name="method_tcp_socket.finish_connect"><code>[method]tcp-socket.finish-connect: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="finish_connect.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.finish_connect.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="finish_connect.0"></a> result&lt;(<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>, <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>), <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.finish_connect.0"></a> result&lt;(own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;, own&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;), <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="start_listen"><code>start-listen: func</code></a></h4>
+<h4><a name="method_tcp_socket.start_listen"><code>[method]tcp-socket.start-listen: func</code></a></h4>
 <p>Start listening for new connections.</p>
 <p>Transitions the socket into the Listener state.</p>
 <p>Unlike POSIX:</p>
@@ -2053,22 +1969,22 @@ implicitly bind the socket.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="start_listen.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.start_listen.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="start_listen.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.start_listen.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="finish_listen"><code>finish-listen: func</code></a></h4>
+<h4><a name="method_tcp_socket.finish_listen"><code>[method]tcp-socket.finish-listen: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="finish_listen.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.finish_listen.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="finish_listen.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.finish_listen.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="accept"><code>accept: func</code></a></h4>
+<h4><a name="method_tcp_socket.accept"><code>[method]tcp-socket.accept: func</code></a></h4>
 <p>Accept a new client socket.</p>
 <p>The returned socket is bound and in the Connection state.</p>
 <p>On success, this function returns the newly accepted client socket along with
@@ -2088,13 +2004,13 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="accept.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.accept.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="accept.0"></a> result&lt;(<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>, <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>, <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>), <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.accept.0"></a> result&lt;(own&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;, own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;, own&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;), <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="local_address"><code>local-address: func</code></a></h4>
+<h4><a name="method_tcp_socket.local_address"><code>[method]tcp-socket.local-address: func</code></a></h4>
 <p>Get the bound local address.</p>
 <h1>Typical errors</h1>
 <ul>
@@ -2109,13 +2025,13 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="local_address.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.local_address.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="local_address.0"></a> result&lt;<a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.local_address.0"></a> result&lt;<a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="remote_address"><code>remote-address: func</code></a></h4>
+<h4><a name="method_tcp_socket.remote_address"><code>[method]tcp-socket.remote-address: func</code></a></h4>
 <p>Get the bound remote address.</p>
 <h1>Typical errors</h1>
 <ul>
@@ -2130,24 +2046,24 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="remote_address.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.remote_address.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="remote_address.0"></a> result&lt;<a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.remote_address.0"></a> result&lt;<a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="address_family"><code>address-family: func</code></a></h4>
+<h4><a name="method_tcp_socket.address_family"><code>[method]tcp-socket.address-family: func</code></a></h4>
 <p>Whether this is a IPv4 or IPv6 socket.</p>
 <p>Equivalent to the SO_DOMAIN socket option.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="address_family.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.address_family.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="address_family.0"></a> <a href="#ip_address_family"><a href="#ip_address_family"><code>ip-address-family</code></a></a></li>
+<li><a name="method_tcp_socket.address_family.0"></a> <a href="#ip_address_family"><a href="#ip_address_family"><code>ip-address-family</code></a></a></li>
 </ul>
-<h4><a name="ipv6_only"><code>ipv6-only: func</code></a></h4>
+<h4><a name="method_tcp_socket.ipv6_only"><code>[method]tcp-socket.ipv6-only: func</code></a></h4>
 <p>Whether IPv4 compatibility (dual-stack) mode is disabled or not.</p>
 <p>Equivalent to the IPV6_V6ONLY socket option.</p>
 <h1>Typical errors</h1>
@@ -2159,23 +2075,23 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="ipv6_only.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.ipv6_only.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="ipv6_only.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.ipv6_only.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_ipv6_only"><code>set-ipv6-only: func</code></a></h4>
+<h4><a name="method_tcp_socket.set_ipv6_only"><code>[method]tcp-socket.set-ipv6-only: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="set_ipv6_only.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="set_ipv6_only.value"><code>value</code></a>: <code>bool</code></li>
+<li><a name="method_tcp_socket.set_ipv6_only.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_ipv6_only.value"><code>value</code></a>: <code>bool</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_ipv6_only.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_ipv6_only.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_listen_backlog_size"><code>set-listen-backlog-size: func</code></a></h4>
+<h4><a name="method_tcp_socket.set_listen_backlog_size"><code>[method]tcp-socket.set-listen-backlog-size: func</code></a></h4>
 <p>Hints the desired listen queue size. Implementations are free to ignore this.</p>
 <h1>Typical errors</h1>
 <ul>
@@ -2184,14 +2100,14 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="set_listen_backlog_size.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="set_listen_backlog_size.value"><code>value</code></a>: <code>u64</code></li>
+<li><a name="method_tcp_socket.set_listen_backlog_size.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_listen_backlog_size.value"><code>value</code></a>: <code>u64</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_listen_backlog_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_listen_backlog_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="keep_alive"><code>keep-alive: func</code></a></h4>
+<h4><a name="method_tcp_socket.keep_alive"><code>[method]tcp-socket.keep-alive: func</code></a></h4>
 <p>Equivalent to the SO_KEEPALIVE socket option.</p>
 <h1>Typical errors</h1>
 <ul>
@@ -2199,23 +2115,23 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="keep_alive.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.keep_alive.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="keep_alive.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.keep_alive.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_keep_alive"><code>set-keep-alive: func</code></a></h4>
+<h4><a name="method_tcp_socket.set_keep_alive"><code>[method]tcp-socket.set-keep-alive: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="set_keep_alive.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="set_keep_alive.value"><code>value</code></a>: <code>bool</code></li>
+<li><a name="method_tcp_socket.set_keep_alive.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_keep_alive.value"><code>value</code></a>: <code>bool</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_keep_alive.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_keep_alive.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="no_delay"><code>no-delay: func</code></a></h4>
+<h4><a name="method_tcp_socket.no_delay"><code>[method]tcp-socket.no-delay: func</code></a></h4>
 <p>Equivalent to the TCP_NODELAY socket option.</p>
 <h1>Typical errors</h1>
 <ul>
@@ -2223,23 +2139,23 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="no_delay.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.no_delay.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="no_delay.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.no_delay.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_no_delay"><code>set-no-delay: func</code></a></h4>
+<h4><a name="method_tcp_socket.set_no_delay"><code>[method]tcp-socket.set-no-delay: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="set_no_delay.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="set_no_delay.value"><code>value</code></a>: <code>bool</code></li>
+<li><a name="method_tcp_socket.set_no_delay.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_no_delay.value"><code>value</code></a>: <code>bool</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_no_delay.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_no_delay.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="unicast_hop_limit"><code>unicast-hop-limit: func</code></a></h4>
+<h4><a name="method_tcp_socket.unicast_hop_limit"><code>[method]tcp-socket.unicast-hop-limit: func</code></a></h4>
 <p>Equivalent to the IP_TTL &amp; IPV6_UNICAST_HOPS socket options.</p>
 <h1>Typical errors</h1>
 <ul>
@@ -2249,23 +2165,23 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="unicast_hop_limit.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.unicast_hop_limit.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="unicast_hop_limit.0"></a> result&lt;<code>u8</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.unicast_hop_limit.0"></a> result&lt;<code>u8</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_unicast_hop_limit"><code>set-unicast-hop-limit: func</code></a></h4>
+<h4><a name="method_tcp_socket.set_unicast_hop_limit"><code>[method]tcp-socket.set-unicast-hop-limit: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="set_unicast_hop_limit.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="set_unicast_hop_limit.value"><code>value</code></a>: <code>u8</code></li>
+<li><a name="method_tcp_socket.set_unicast_hop_limit.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_unicast_hop_limit.value"><code>value</code></a>: <code>u8</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_unicast_hop_limit.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_unicast_hop_limit.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="receive_buffer_size"><code>receive-buffer-size: func</code></a></h4>
+<h4><a name="method_tcp_socket.receive_buffer_size"><code>[method]tcp-socket.receive-buffer-size: func</code></a></h4>
 <p>The kernel buffer space reserved for sends/receives on this socket.</p>
 <p>Note #1: an implementation may choose to cap or round the buffer size when setting the value.
 In other words, after setting a value, reading the same setting back may return a different value.</p>
@@ -2281,59 +2197,59 @@ for internal metadata structures.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="receive_buffer_size.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.receive_buffer_size.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="receive_buffer_size.0"></a> result&lt;<code>u64</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.receive_buffer_size.0"></a> result&lt;<code>u64</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_receive_buffer_size"><code>set-receive-buffer-size: func</code></a></h4>
+<h4><a name="method_tcp_socket.set_receive_buffer_size"><code>[method]tcp-socket.set-receive-buffer-size: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="set_receive_buffer_size.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="set_receive_buffer_size.value"><code>value</code></a>: <code>u64</code></li>
+<li><a name="method_tcp_socket.set_receive_buffer_size.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_receive_buffer_size.value"><code>value</code></a>: <code>u64</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_receive_buffer_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_receive_buffer_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="send_buffer_size"><code>send-buffer-size: func</code></a></h4>
+<h4><a name="method_tcp_socket.send_buffer_size"><code>[method]tcp-socket.send-buffer-size: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="send_buffer_size.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.send_buffer_size.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="send_buffer_size.0"></a> result&lt;<code>u64</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.send_buffer_size.0"></a> result&lt;<code>u64</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_send_buffer_size"><code>set-send-buffer-size: func</code></a></h4>
+<h4><a name="method_tcp_socket.set_send_buffer_size"><code>[method]tcp-socket.set-send-buffer-size: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="set_send_buffer_size.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="set_send_buffer_size.value"><code>value</code></a>: <code>u64</code></li>
+<li><a name="method_tcp_socket.set_send_buffer_size.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_send_buffer_size.value"><code>value</code></a>: <code>u64</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_send_buffer_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.set_send_buffer_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="subscribe"><code>subscribe: func</code></a></h4>
+<h4><a name="method_tcp_socket.subscribe"><code>[method]tcp-socket.subscribe: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once the socket is ready for I/O.</p>
 <p>Note: this function is here for WASI Preview2 only.
 It's planned to be removed when <code>future</code> is natively supported in Preview3.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="subscribe.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.subscribe.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="subscribe.0"></a> <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
+<li><a name="method_tcp_socket.subscribe.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
 </ul>
-<h4><a name="shutdown"><code>shutdown: func</code></a></h4>
+<h4><a name="method_tcp_socket.shutdown"><code>[method]tcp-socket.shutdown: func</code></a></h4>
 <p>Initiate a graceful shutdown.</p>
 <ul>
 <li>receive: the socket is not expecting to receive any more data from the peer. All subsequent read
 operations on the <a href="#input_stream"><code>input-stream</code></a> associated with this socket will return an End Of Stream indication.
-Any data still in the receive queue at time of calling <a href="#shutdown"><code>shutdown</code></a> will be discarded.</li>
+Any data still in the receive queue at time of calling <code>shutdown</code> will be discarded.</li>
 <li>send: the socket is not expecting to send any more data to the peer. All subsequent write
 operations on the <a href="#output_stream"><code>output-stream</code></a> associated with this socket will return an error.</li>
 <li>both: same effect as receive &amp; send combined.</li>
@@ -2352,20 +2268,12 @@ operations on the <a href="#output_stream"><code>output-stream</code></a> associ
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="shutdown.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="shutdown.shutdown_type"><a href="#shutdown_type"><code>shutdown-type</code></a></a>: <a href="#shutdown_type"><a href="#shutdown_type"><code>shutdown-type</code></a></a></li>
+<li><a name="method_tcp_socket.shutdown.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
+<li><a name="method_tcp_socket.shutdown.shutdown_type"><a href="#shutdown_type"><code>shutdown-type</code></a></a>: <a href="#shutdown_type"><a href="#shutdown_type"><code>shutdown-type</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="shutdown.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
-</ul>
-<h4><a name="drop_tcp_socket"><code>drop-tcp-socket: func</code></a></h4>
-<p>Dispose of the specified <a href="#tcp_socket"><code>tcp-socket</code></a>, after which it may no longer be used.</p>
-<p>Similar to the POSIX <code>close</code> function.</p>
-<p>Note: this function is scheduled to be removed when Resources are natively supported in Wit.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="drop_tcp_socket.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="method_tcp_socket.shutdown.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:sockets_tcp_create_socket">Import interface wasi:sockets/tcp-create-socket</a></h2>
 <hr />
@@ -2394,7 +2302,7 @@ is called, the socket is effectively an in-memory configuration object, unable t
 <h1>Typical errors</h1>
 <ul>
 <li><code>not-supported</code>:                The host does not support TCP sockets. (EOPNOTSUPP)</li>
-<li><code>address-family-not-supported</code>: The specified <a href="#address_family"><code>address-family</code></a> is not supported. (EAFNOSUPPORT)</li>
+<li><code>address-family-not-supported</code>: The specified <code>address-family</code> is not supported. (EAFNOSUPPORT)</li>
 <li><code>new-socket-limit</code>:             The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)</li>
 </ul>
 <h1>References</h1>
@@ -2406,11 +2314,11 @@ is called, the socket is effectively an in-memory configuration object, unable t
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="create_tcp_socket.address_family"><a href="#address_family"><code>address-family</code></a></a>: <a href="#ip_address_family"><a href="#ip_address_family"><code>ip-address-family</code></a></a></li>
+<li><a name="create_tcp_socket.address_family"><code>address-family</code></a>: <a href="#ip_address_family"><a href="#ip_address_family"><code>ip-address-family</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="create_tcp_socket.0"></a> result&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="create_tcp_socket.0"></a> result&lt;own&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:sockets_udp">Import interface wasi:sockets/udp</a></h2>
 <hr />
@@ -2430,18 +2338,18 @@ is called, the socket is effectively an in-memory configuration object, unable t
 #### <a name="ip_address_family">`type ip-address-family`</a>
 [`ip-address-family`](#ip_address_family)
 <p>
-#### <a name="udp_socket">`type udp-socket`</a>
-`u32`
-<p>A UDP socket handle.
-<h4><a name="datagram"><code>record datagram</code></a></h4>
+#### <a name="datagram">`record datagram`</a>
 <h5>Record Fields</h5>
 <ul>
 <li><a name="datagram.data"><code>data</code></a>: list&lt;<code>u8</code>&gt;</li>
-<li><a name="datagram.remote_address"><a href="#remote_address"><code>remote-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
+<li><a name="datagram.remote_address"><code>remote-address</code></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
 </ul>
+<h4><a name="udp_socket"><code>resource udp-socket</code></a></h4>
+<h5>Resource Members</h5>
+<p>TODO</p>
 <hr />
 <h3>Functions</h3>
-<h4><a name="start_bind"><code>start-bind: func</code></a></h4>
+<h4><a name="method_udp_socket.start_bind"><code>[method]udp-socket.start-bind: func</code></a></h4>
 <p>Bind the socket to a specific network on the provided IP address and port.</p>
 <p>If the IP address is zero (<code>0.0.0.0</code> in IPv4, <code>::</code> in IPv6), it is left to the implementation to decide which
 network interface(s) to bind to.
@@ -2450,7 +2358,7 @@ If the TCP/UDP port is zero, the socket will be bound to a random free port.</p>
 <p>Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.</p>
 <h1>Typical <code>start</code> errors</h1>
 <ul>
-<li><code>address-family-mismatch</code>:   The <a href="#local_address"><code>local-address</code></a> has the wrong address family. (EINVAL)</li>
+<li><code>address-family-mismatch</code>:   The <code>local-address</code> has the wrong address family. (EINVAL)</li>
 <li><code>already-bound</code>:             The socket is already bound. (EINVAL)</li>
 <li><code>concurrency-conflict</code>:      Another <code>bind</code> or <code>connect</code> operation is already in progress. (EALREADY)</li>
 </ul>
@@ -2458,7 +2366,7 @@ If the TCP/UDP port is zero, the socket will be bound to a random free port.</p>
 <ul>
 <li><code>ephemeral-ports-exhausted</code>: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)</li>
 <li><code>address-in-use</code>:            Address is already in use. (EADDRINUSE)</li>
-<li><code>address-not-bindable</code>:      <a href="#local_address"><code>local-address</code></a> is not an address that the <a href="#network"><code>network</code></a> can bind to. (EADDRNOTAVAIL)</li>
+<li><code>address-not-bindable</code>:      <code>local-address</code> is not an address that the <a href="#network"><code>network</code></a> can bind to. (EADDRNOTAVAIL)</li>
 <li><code>not-in-progress</code>:           A <code>bind</code> operation is not in progress.</li>
 <li><code>would-block</code>:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)</li>
 </ul>
@@ -2471,38 +2379,38 @@ If the TCP/UDP port is zero, the socket will be bound to a random free port.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="start_bind.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
-<li><a name="start_bind.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
-<li><a name="start_bind.local_address"><a href="#local_address"><code>local-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
+<li><a name="method_udp_socket.start_bind.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.start_bind.network"><a href="#network"><code>network</code></a></a>: own&lt;<a href="#network"><a href="#network"><code>network</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.start_bind.local_address"><code>local-address</code></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="start_bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.start_bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="finish_bind"><code>finish-bind: func</code></a></h4>
+<h4><a name="method_udp_socket.finish_bind"><code>[method]udp-socket.finish-bind: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="finish_bind.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="method_udp_socket.finish_bind.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="finish_bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.finish_bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="start_connect"><code>start-connect: func</code></a></h4>
+<h4><a name="method_udp_socket.start_connect"><code>[method]udp-socket.start-connect: func</code></a></h4>
 <p>Set the destination address.</p>
-<p>The local-address is updated based on the best network path to <a href="#remote_address"><code>remote-address</code></a>.</p>
+<p>The local-address is updated based on the best network path to <code>remote-address</code>.</p>
 <p>When a destination address is set:</p>
 <ul>
-<li>all receive operations will only return datagrams sent from the provided <a href="#remote_address"><code>remote-address</code></a>.</li>
-<li>the <a href="#send"><code>send</code></a> function can only be used to send to this destination.</li>
+<li>all receive operations will only return datagrams sent from the provided <code>remote-address</code>.</li>
+<li>the <code>send</code> function can only be used to send to this destination.</li>
 </ul>
 <p>Note that this function does not generate any network traffic and the peer is not aware of this &quot;connection&quot;.</p>
 <p>Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.</p>
 <h1>Typical <code>start</code> errors</h1>
 <ul>
-<li><code>address-family-mismatch</code>:   The <a href="#remote_address"><code>remote-address</code></a> has the wrong address family. (EAFNOSUPPORT)</li>
-<li><code>invalid-remote-address</code>:    The IP address in <a href="#remote_address"><code>remote-address</code></a> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EDESTADDRREQ, EADDRNOTAVAIL)</li>
-<li><code>invalid-remote-address</code>:    The port in <a href="#remote_address"><code>remote-address</code></a> is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)</li>
+<li><code>address-family-mismatch</code>:   The <code>remote-address</code> has the wrong address family. (EAFNOSUPPORT)</li>
+<li><code>invalid-remote-address</code>:    The IP address in <code>remote-address</code> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EDESTADDRREQ, EADDRNOTAVAIL)</li>
+<li><code>invalid-remote-address</code>:    The port in <code>remote-address</code> is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)</li>
 <li><code>already-attached</code>:          The socket is already bound to a different network. The <a href="#network"><code>network</code></a> passed to <code>connect</code> must be identical to the one passed to <code>bind</code>.</li>
 <li><code>concurrency-conflict</code>:      Another <code>bind</code> or <code>connect</code> operation is already in progress. (EALREADY)</li>
 </ul>
@@ -2521,24 +2429,24 @@ If the TCP/UDP port is zero, the socket will be bound to a random free port.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="start_connect.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
-<li><a name="start_connect.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
-<li><a name="start_connect.remote_address"><a href="#remote_address"><code>remote-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
+<li><a name="method_udp_socket.start_connect.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.start_connect.network"><a href="#network"><code>network</code></a></a>: own&lt;<a href="#network"><a href="#network"><code>network</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.start_connect.remote_address"><code>remote-address</code></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="start_connect.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.start_connect.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="finish_connect"><code>finish-connect: func</code></a></h4>
+<h4><a name="method_udp_socket.finish_connect"><code>[method]udp-socket.finish-connect: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="finish_connect.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="method_udp_socket.finish_connect.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="finish_connect.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.finish_connect.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="receive"><code>receive: func</code></a></h4>
+<h4><a name="method_udp_socket.receive"><code>[method]udp-socket.receive: func</code></a></h4>
 <p>Receive a message.</p>
 <p>Returns:</p>
 <ul>
@@ -2563,21 +2471,21 @@ If the TCP/UDP port is zero, the socket will be bound to a random free port.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="receive.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="method_udp_socket.receive.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="receive.0"></a> result&lt;<a href="#datagram"><a href="#datagram"><code>datagram</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.receive.0"></a> result&lt;<a href="#datagram"><a href="#datagram"><code>datagram</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="send"><code>send: func</code></a></h4>
+<h4><a name="method_udp_socket.send"><code>[method]udp-socket.send: func</code></a></h4>
 <p>Send a message to a specific destination address.</p>
 <p>The remote address option is required. To send a message to the &quot;connected&quot; peer,
-call <a href="#remote_address"><code>remote-address</code></a> to get their address.</p>
+call <code>remote-address</code> to get their address.</p>
 <h1>Typical errors</h1>
 <ul>
-<li><code>address-family-mismatch</code>: The <a href="#remote_address"><code>remote-address</code></a> has the wrong address family. (EAFNOSUPPORT)</li>
-<li><code>invalid-remote-address</code>:  The IP address in <a href="#remote_address"><code>remote-address</code></a> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EDESTADDRREQ, EADDRNOTAVAIL)</li>
-<li><code>invalid-remote-address</code>:  The port in <a href="#remote_address"><code>remote-address</code></a> is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)</li>
+<li><code>address-family-mismatch</code>: The <code>remote-address</code> has the wrong address family. (EAFNOSUPPORT)</li>
+<li><code>invalid-remote-address</code>:  The IP address in <code>remote-address</code> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EDESTADDRREQ, EADDRNOTAVAIL)</li>
+<li><code>invalid-remote-address</code>:  The port in <code>remote-address</code> is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)</li>
 <li><code>already-connected</code>:       The socket is in &quot;connected&quot; mode and the <code>datagram.remote-address</code> does not match the address passed to <code>connect</code>. (EISCONN)</li>
 <li><code>not-bound</code>:               The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.</li>
 <li><code>remote-unreachable</code>:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)</li>
@@ -2596,14 +2504,14 @@ call <a href="#remote_address"><code>remote-address</code></a> to get their addr
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="send.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
-<li><a name="send.datagram"><a href="#datagram"><code>datagram</code></a></a>: <a href="#datagram"><a href="#datagram"><code>datagram</code></a></a></li>
+<li><a name="method_udp_socket.send.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.send.datagram"><a href="#datagram"><code>datagram</code></a></a>: <a href="#datagram"><a href="#datagram"><code>datagram</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="send.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.send.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="local_address"><code>local-address: func</code></a></h4>
+<h4><a name="method_udp_socket.local_address"><code>[method]udp-socket.local-address: func</code></a></h4>
 <p>Get the current bound address.</p>
 <h1>Typical errors</h1>
 <ul>
@@ -2618,13 +2526,13 @@ call <a href="#remote_address"><code>remote-address</code></a> to get their addr
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="local_address.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="method_udp_socket.local_address.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="local_address.0"></a> result&lt;<a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.local_address.0"></a> result&lt;<a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="remote_address"><code>remote-address: func</code></a></h4>
+<h4><a name="method_udp_socket.remote_address"><code>[method]udp-socket.remote-address: func</code></a></h4>
 <p>Get the address set with <code>connect</code>.</p>
 <h1>Typical errors</h1>
 <ul>
@@ -2639,24 +2547,24 @@ call <a href="#remote_address"><code>remote-address</code></a> to get their addr
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="remote_address.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="method_udp_socket.remote_address.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="remote_address.0"></a> result&lt;<a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.remote_address.0"></a> result&lt;<a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="address_family"><code>address-family: func</code></a></h4>
+<h4><a name="method_udp_socket.address_family"><code>[method]udp-socket.address-family: func</code></a></h4>
 <p>Whether this is a IPv4 or IPv6 socket.</p>
 <p>Equivalent to the SO_DOMAIN socket option.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="address_family.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="method_udp_socket.address_family.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="address_family.0"></a> <a href="#ip_address_family"><a href="#ip_address_family"><code>ip-address-family</code></a></a></li>
+<li><a name="method_udp_socket.address_family.0"></a> <a href="#ip_address_family"><a href="#ip_address_family"><code>ip-address-family</code></a></a></li>
 </ul>
-<h4><a name="ipv6_only"><code>ipv6-only: func</code></a></h4>
+<h4><a name="method_udp_socket.ipv6_only"><code>[method]udp-socket.ipv6-only: func</code></a></h4>
 <p>Whether IPv4 compatibility (dual-stack) mode is disabled or not.</p>
 <p>Equivalent to the IPV6_V6ONLY socket option.</p>
 <h1>Typical errors</h1>
@@ -2668,23 +2576,23 @@ call <a href="#remote_address"><code>remote-address</code></a> to get their addr
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="ipv6_only.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="method_udp_socket.ipv6_only.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="ipv6_only.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.ipv6_only.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_ipv6_only"><code>set-ipv6-only: func</code></a></h4>
+<h4><a name="method_udp_socket.set_ipv6_only"><code>[method]udp-socket.set-ipv6-only: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="set_ipv6_only.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
-<li><a name="set_ipv6_only.value"><code>value</code></a>: <code>bool</code></li>
+<li><a name="method_udp_socket.set_ipv6_only.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.set_ipv6_only.value"><code>value</code></a>: <code>bool</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_ipv6_only.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.set_ipv6_only.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="unicast_hop_limit"><code>unicast-hop-limit: func</code></a></h4>
+<h4><a name="method_udp_socket.unicast_hop_limit"><code>[method]udp-socket.unicast-hop-limit: func</code></a></h4>
 <p>Equivalent to the IP_TTL &amp; IPV6_UNICAST_HOPS socket options.</p>
 <h1>Typical errors</h1>
 <ul>
@@ -2692,23 +2600,23 @@ call <a href="#remote_address"><code>remote-address</code></a> to get their addr
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="unicast_hop_limit.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="method_udp_socket.unicast_hop_limit.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="unicast_hop_limit.0"></a> result&lt;<code>u8</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.unicast_hop_limit.0"></a> result&lt;<code>u8</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_unicast_hop_limit"><code>set-unicast-hop-limit: func</code></a></h4>
+<h4><a name="method_udp_socket.set_unicast_hop_limit"><code>[method]udp-socket.set-unicast-hop-limit: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="set_unicast_hop_limit.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
-<li><a name="set_unicast_hop_limit.value"><code>value</code></a>: <code>u8</code></li>
+<li><a name="method_udp_socket.set_unicast_hop_limit.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.set_unicast_hop_limit.value"><code>value</code></a>: <code>u8</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_unicast_hop_limit.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.set_unicast_hop_limit.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="receive_buffer_size"><code>receive-buffer-size: func</code></a></h4>
+<h4><a name="method_udp_socket.receive_buffer_size"><code>[method]udp-socket.receive-buffer-size: func</code></a></h4>
 <p>The kernel buffer space reserved for sends/receives on this socket.</p>
 <p>Note #1: an implementation may choose to cap or round the buffer size when setting the value.
 In other words, after setting a value, reading the same setting back may return a different value.</p>
@@ -2723,59 +2631,52 @@ for internal metadata structures.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="receive_buffer_size.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="method_udp_socket.receive_buffer_size.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="receive_buffer_size.0"></a> result&lt;<code>u64</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.receive_buffer_size.0"></a> result&lt;<code>u64</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_receive_buffer_size"><code>set-receive-buffer-size: func</code></a></h4>
+<h4><a name="method_udp_socket.set_receive_buffer_size"><code>[method]udp-socket.set-receive-buffer-size: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="set_receive_buffer_size.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
-<li><a name="set_receive_buffer_size.value"><code>value</code></a>: <code>u64</code></li>
+<li><a name="method_udp_socket.set_receive_buffer_size.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.set_receive_buffer_size.value"><code>value</code></a>: <code>u64</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_receive_buffer_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.set_receive_buffer_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="send_buffer_size"><code>send-buffer-size: func</code></a></h4>
+<h4><a name="method_udp_socket.send_buffer_size"><code>[method]udp-socket.send-buffer-size: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="send_buffer_size.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="method_udp_socket.send_buffer_size.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="send_buffer_size.0"></a> result&lt;<code>u64</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.send_buffer_size.0"></a> result&lt;<code>u64</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_send_buffer_size"><code>set-send-buffer-size: func</code></a></h4>
+<h4><a name="method_udp_socket.set_send_buffer_size"><code>[method]udp-socket.set-send-buffer-size: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="set_send_buffer_size.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
-<li><a name="set_send_buffer_size.value"><code>value</code></a>: <code>u64</code></li>
+<li><a name="method_udp_socket.set_send_buffer_size.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.set_send_buffer_size.value"><code>value</code></a>: <code>u64</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_send_buffer_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="method_udp_socket.set_send_buffer_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="subscribe"><code>subscribe: func</code></a></h4>
+<h4><a name="method_udp_socket.subscribe"><code>[method]udp-socket.subscribe: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once the socket is ready for I/O.</p>
 <p>Note: this function is here for WASI Preview2 only.
 It's planned to be removed when <code>future</code> is natively supported in Preview3.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="subscribe.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="method_udp_socket.subscribe.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="subscribe.0"></a> <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
-</ul>
-<h4><a name="drop_udp_socket"><code>drop-udp-socket: func</code></a></h4>
-<p>Dispose of the specified <a href="#udp_socket"><code>udp-socket</code></a>, after which it may no longer be used.</p>
-<p>Note: this function is scheduled to be removed when Resources are natively supported in Wit.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="drop_udp_socket.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="method_udp_socket.subscribe.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:sockets_udp_create_socket">Import interface wasi:sockets/udp-create-socket</a></h2>
 <hr />
@@ -2804,7 +2705,7 @@ the socket is effectively an in-memory configuration object, unable to communica
 <h1>Typical errors</h1>
 <ul>
 <li><code>not-supported</code>:                The host does not support UDP sockets. (EOPNOTSUPP)</li>
-<li><code>address-family-not-supported</code>: The specified <a href="#address_family"><code>address-family</code></a> is not supported. (EAFNOSUPPORT)</li>
+<li><code>address-family-not-supported</code>: The specified <code>address-family</code> is not supported. (EAFNOSUPPORT)</li>
 <li><code>new-socket-limit</code>:             The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)</li>
 </ul>
 <h1>References:</h1>
@@ -2816,11 +2717,11 @@ the socket is effectively an in-memory configuration object, unable to communica
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="create_udp_socket.address_family"><a href="#address_family"><code>address-family</code></a></a>: <a href="#ip_address_family"><a href="#ip_address_family"><code>ip-address-family</code></a></a></li>
+<li><a name="create_udp_socket.address_family"><code>address-family</code></a>: <a href="#ip_address_family"><a href="#ip_address_family"><code>ip-address-family</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="create_udp_socket.0"></a> result&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="create_udp_socket.0"></a> result&lt;own&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:random_random">Import interface wasi:random/random</a></h2>
 <p>WASI Random is a random data API.</p>
@@ -2944,7 +2845,7 @@ values each time it is called.</p>
 <p>Return the set of of preopened directories, and their path.</p>
 <h5>Return values</h5>
 <ul>
-<li><a name="get_directories.0"></a> list&lt;(<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>, <code>string</code>)&gt;</li>
+<li><a name="get_directories.0"></a> list&lt;(own&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;, <code>string</code>)&gt;</li>
 </ul>
 <h4><a name="initial_cwd"><code>initial-cwd: func</code></a></h4>
 <p>Return a path that programs should use as their initial current working
@@ -2957,7 +2858,7 @@ directory, interpreting <code>.</code> as shorthand for this.</p>
 <hr />
 <h3>Functions</h3>
 <h4><a name="exit"><code>exit: func</code></a></h4>
-<p>Exit the curerent instance and any linked instances.</p>
+<p>Exit the current instance and any linked instances.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="exit.status"><code>status</code></a>: result</li>
@@ -2973,7 +2874,7 @@ directory, interpreting <code>.</code> as shorthand for this.</p>
 <h4><a name="get_stdin"><code>get-stdin: func</code></a></h4>
 <h5>Return values</h5>
 <ul>
-<li><a name="get_stdin.0"></a> <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+<li><a name="get_stdin.0"></a> own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:cli_stdout">Import interface wasi:cli/stdout</a></h2>
 <hr />
@@ -2986,7 +2887,7 @@ directory, interpreting <code>.</code> as shorthand for this.</p>
 <h4><a name="get_stdout"><code>get-stdout: func</code></a></h4>
 <h5>Return values</h5>
 <ul>
-<li><a name="get_stdout.0"></a> <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a name="get_stdout.0"></a> own&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:cli_stderr">Import interface wasi:cli/stderr</a></h2>
 <hr />
@@ -2999,7 +2900,7 @@ directory, interpreting <code>.</code> as shorthand for this.</p>
 <h4><a name="get_stderr"><code>get-stderr: func</code></a></h4>
 <h5>Return values</h5>
 <ul>
-<li><a name="get_stderr.0"></a> <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a name="get_stderr.0"></a> own&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:cli_run">Export interface wasi:cli/run</a></h2>
 <hr />

--- a/wit/deps/clocks/timezone.wit
+++ b/wit/deps/clocks/timezone.wit
@@ -6,25 +6,19 @@ interface timezone {
     /// In timezones that recognize daylight saving time, also known as daylight
     /// time and summer time, the information returned from the functions varies
     /// over time to reflect these adjustments.
-    ///
-    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
-    type timezone = u32
+    resource timezone {
+        /// Return information needed to display the given `datetime`. This includes
+        /// the UTC offset, the time zone name, and a flag indicating whether
+        /// daylight saving time is active.
+        ///
+        /// If the timezone cannot be determined for the given `datetime`, return a
+        /// `timezone-display` for `UTC` with a `utc-offset` of 0 and no daylight
+        /// saving time.
+        display: func(when: datetime) -> timezone-display
 
-    /// Return information needed to display the given `datetime`. This includes
-    /// the UTC offset, the time zone name, and a flag indicating whether
-    /// daylight saving time is active.
-    ///
-    /// If the timezone cannot be determined for the given `datetime`, return a
-    /// `timezone-display` for `UTC` with a `utc-offset` of 0 and no daylight
-    /// saving time.
-    display: func(this: timezone, when: datetime) -> timezone-display
-
-    /// The same as `display`, but only return the UTC offset.
-    utc-offset: func(this: timezone, when: datetime) -> s32
-
-    /// Dispose of the specified input-stream, after which it may no longer
-    /// be used.
-    drop-timezone: func(this: timezone)
+        /// The same as `display`, but only return the UTC offset.
+        utc-offset: func(when: datetime) -> s32
+    }
 
     /// Information useful for displaying the timezone of a specific `datetime`.
     ///

--- a/wit/deps/filesystem/preopens.wit
+++ b/wit/deps/filesystem/preopens.wit
@@ -1,0 +1,6 @@
+interface preopens {
+    use types.{descriptor}
+
+    /// Return the set of preopened directories, and their path.
+    get-directories: func() -> list<tuple<descriptor, string>>
+}

--- a/wit/deps/filesystem/types.wit
+++ b/wit/deps/filesystem/types.wit
@@ -102,10 +102,6 @@ interface types {
     ///
     /// Note: This was called `filestat` in earlier versions of WASI.
     record descriptor-stat {
-        /// Device ID of device containing the file.
-        device: device,
-        /// File serial number.
-        inode: inode,
         /// File type.
         %type: descriptor-type,
         /// Number of hard links to the file.
@@ -166,14 +162,6 @@ interface types {
     /// Number of hard links to an inode.
     type link-count = u64
 
-    /// Identifier for a device containing a file system. Can be used in
-    /// combination with `inode` to uniquely identify a file or directory in
-    /// the filesystem.
-    type device = u64
-
-    /// Filesystem object serial number that is unique within its file system.
-    type inode = u64
-
     /// When setting a timestamp, this gives the value to set it to.
     variant new-timestamp {
         /// Leave the timestamp set to its previous value.
@@ -187,14 +175,6 @@ interface types {
 
     /// A directory entry.
     record directory-entry {
-        /// The serial number of the object referred to by this directory entry.
-        /// May be none if the inode value is not known.
-        ///
-        /// When this is none, libc implementations might do an extra `stat-at`
-        /// call to retrieve the inode number to fill their `d_ino` fields, so
-        /// implementations which can set this to a non-none value should do so.
-        inode: option<inode>,
-
         /// The type of the file referred to by this directory entry.
         %type: descriptor-type,
 
@@ -305,493 +285,519 @@ interface types {
         no-reuse,
     }
 
+    /// A 128-bit hash value, split into parts because wasm doesn't have a
+    /// 128-bit integer type.
+    record metadata-hash-value {
+       /// 64 bits of a 128-bit hash value.
+       lower: u64,
+       /// Another 64 bits of a 128-bit hash value.
+       upper: u64,
+    }
+
     /// A descriptor is a reference to a filesystem object, which may be a file,
     /// directory, named pipe, special file, or other object on which filesystem
     /// calls may be made.
-    ///
-    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
-    type descriptor = u32
+    resource descriptor {
+        /// Return a stream for reading from a file, if available.
+        ///
+        /// May fail with an error-code describing why the file cannot be read.
+        ///
+        /// Multiple read, write, and append streams may be active on the same open
+        /// file and they do not interfere with each other.
+        ///
+        /// Note: This allows using `read-stream`, which is similar to `read` in POSIX.
+        read-via-stream: func(
+            /// The offset within the file at which to start reading.
+            offset: filesize,
+        ) -> result<input-stream, error-code>
 
-    /// Return a stream for reading from a file.
-    ///
-    /// Multiple read, write, and append streams may be active on the same open
-    /// file and they do not interfere with each other.
-    ///
-    /// Note: This allows using `read-stream`, which is similar to `read` in POSIX.
-    read-via-stream: func(
-        this: descriptor,
-        /// The offset within the file at which to start reading.
-        offset: filesize,
-    ) -> input-stream
+        /// Return a stream for writing to a file, if available.
+        ///
+        /// May fail with an error-code describing why the file cannot be written.
+        ///
+        /// Note: This allows using `write-stream`, which is similar to `write` in
+        /// POSIX.
+        write-via-stream: func(
+            /// The offset within the file at which to start writing.
+            offset: filesize,
+        ) -> result<output-stream, error-code>
 
-    /// Return a stream for writing to a file.
-    ///
-    /// Note: This allows using `write-stream`, which is similar to `write` in
-    /// POSIX.
-    write-via-stream: func(
-        this: descriptor,
-        /// The offset within the file at which to start writing.
-        offset: filesize,
-    ) -> output-stream
+        /// Return a stream for appending to a file, if available.
+        ///
+        /// May fail with an error-code describing why the file cannot be appended.
+        ///
+        /// Note: This allows using `write-stream`, which is similar to `write` with
+        /// `O_APPEND` in in POSIX.
+        append-via-stream: func() -> result<output-stream, error-code>
 
-    /// Return a stream for appending to a file.
-    ///
-    /// Note: This allows using `write-stream`, which is similar to `write` with
-    /// `O_APPEND` in in POSIX.
-    append-via-stream: func(
-        this: descriptor,
-    ) -> output-stream
+        /// Provide file advisory information on a descriptor.
+        ///
+        /// This is similar to `posix_fadvise` in POSIX.
+        advise: func(
+            /// The offset within the file to which the advisory applies.
+            offset: filesize,
+            /// The length of the region to which the advisory applies.
+            length: filesize,
+            /// The advice.
+            advice: advice
+        ) -> result<_, error-code>
 
-    /// Provide file advisory information on a descriptor.
-    ///
-    /// This is similar to `posix_fadvise` in POSIX.
-    advise: func(
-        this: descriptor,
-        /// The offset within the file to which the advisory applies.
-        offset: filesize,
-        /// The length of the region to which the advisory applies.
-        length: filesize,
-        /// The advice.
-        advice: advice
-    ) -> result<_, error-code>
+        /// Synchronize the data of a file to disk.
+        ///
+        /// This function succeeds with no effect if the file descriptor is not
+        /// opened for writing.
+        ///
+        /// Note: This is similar to `fdatasync` in POSIX.
+        sync-data: func() -> result<_, error-code>
 
-    /// Synchronize the data of a file to disk.
-    ///
-    /// This function succeeds with no effect if the file descriptor is not
-    /// opened for writing.
-    ///
-    /// Note: This is similar to `fdatasync` in POSIX.
-    sync-data: func(this: descriptor) -> result<_, error-code>
+        /// Get flags associated with a descriptor.
+        ///
+        /// Note: This returns similar flags to `fcntl(fd, F_GETFL)` in POSIX.
+        ///
+        /// Note: This returns the value that was the `fs_flags` value returned
+        /// from `fdstat_get` in earlier versions of WASI.
+        get-flags: func() -> result<descriptor-flags, error-code>
 
-    /// Get flags associated with a descriptor.
-    ///
-    /// Note: This returns similar flags to `fcntl(fd, F_GETFL)` in POSIX.
-    ///
-    /// Note: This returns the value that was the `fs_flags` value returned
-    /// from `fdstat_get` in earlier versions of WASI.
-    get-flags: func(this: descriptor) -> result<descriptor-flags, error-code>
+        /// Get the dynamic type of a descriptor.
+        ///
+        /// Note: This returns the same value as the `type` field of the `fd-stat`
+        /// returned by `stat`, `stat-at` and similar.
+        ///
+        /// Note: This returns similar flags to the `st_mode & S_IFMT` value provided
+        /// by `fstat` in POSIX.
+        ///
+        /// Note: This returns the value that was the `fs_filetype` value returned
+        /// from `fdstat_get` in earlier versions of WASI.
+        get-type: func() -> result<descriptor-type, error-code>
 
-    /// Get the dynamic type of a descriptor.
-    ///
-    /// Note: This returns the same value as the `type` field of the `fd-stat`
-    /// returned by `stat`, `stat-at` and similar.
-    ///
-    /// Note: This returns similar flags to the `st_mode & S_IFMT` value provided
-    /// by `fstat` in POSIX.
-    ///
-    /// Note: This returns the value that was the `fs_filetype` value returned
-    /// from `fdstat_get` in earlier versions of WASI.
-    get-type: func(this: descriptor) -> result<descriptor-type, error-code>
+        /// Set status flags associated with a descriptor.
+        ///
+        /// This function may only change the `non-blocking` flag.
+        ///
+        /// Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
+        ///
+        /// Note: This was called `fd_fdstat_set_flags` in earlier versions of WASI.
+        set-flags: func(%flags: descriptor-flags) -> result<_, error-code>
 
-    /// Set status flags associated with a descriptor.
-    ///
-    /// This function may only change the `non-blocking` flag.
-    ///
-    /// Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
-    ///
-    /// Note: This was called `fd_fdstat_set_flags` in earlier versions of WASI.
-    set-flags: func(this: descriptor, %flags: descriptor-flags) -> result<_, error-code>
+        /// Adjust the size of an open file. If this increases the file's size, the
+        /// extra bytes are filled with zeros.
+        ///
+        /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
+        set-size: func(size: filesize) -> result<_, error-code>
 
-    /// Adjust the size of an open file. If this increases the file's size, the
-    /// extra bytes are filled with zeros.
-    ///
-    /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
-    set-size: func(this: descriptor, size: filesize) -> result<_, error-code>
+        /// Adjust the timestamps of an open file or directory.
+        ///
+        /// Note: This is similar to `futimens` in POSIX.
+        ///
+        /// Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
+        set-times: func(
+            /// The desired values of the data access timestamp.
+            data-access-timestamp: new-timestamp,
+            /// The desired values of the data modification timestamp.
+            data-modification-timestamp: new-timestamp,
+        ) -> result<_, error-code>
 
-    /// Adjust the timestamps of an open file or directory.
-    ///
-    /// Note: This is similar to `futimens` in POSIX.
-    ///
-    /// Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
-    set-times: func(
-        this: descriptor,
-        /// The desired values of the data access timestamp.
-        data-access-timestamp: new-timestamp,
-        /// The desired values of the data modification timestamp.
-        data-modification-timestamp: new-timestamp,
-    ) -> result<_, error-code>
+        /// Read from a descriptor, without using and updating the descriptor's offset.
+        ///
+        /// This function returns a list of bytes containing the data that was
+        /// read, along with a bool which, when true, indicates that the end of the
+        /// file was reached. The returned list will contain up to `length` bytes; it
+        /// may return fewer than requested, if the end of the file is reached or
+        /// if the I/O operation is interrupted.
+        ///
+        /// In the future, this may change to return a `stream<u8, error-code>`.
+        ///
+        /// Note: This is similar to `pread` in POSIX.
+        read: func(
+            /// The maximum number of bytes to read.
+            length: filesize,
+            /// The offset within the file at which to read.
+            offset: filesize,
+        ) -> result<tuple<list<u8>, bool>, error-code>
 
-    /// Read from a descriptor, without using and updating the descriptor's offset.
-    ///
-    /// This function returns a list of bytes containing the data that was
-    /// read, along with a bool which, when true, indicates that the end of the
-    /// file was reached. The returned list will contain up to `length` bytes; it
-    /// may return fewer than requested, if the end of the file is reached or
-    /// if the I/O operation is interrupted.
-    ///
-    /// In the future, this may change to return a `stream<u8, error-code>`.
-    ///
-    /// Note: This is similar to `pread` in POSIX.
-    read: func(
-        this: descriptor,
-        /// The maximum number of bytes to read.
-        length: filesize,
-        /// The offset within the file at which to read.
-        offset: filesize,
-    ) -> result<tuple<list<u8>, bool>, error-code>
+        /// Write to a descriptor, without using and updating the descriptor's offset.
+        ///
+        /// It is valid to write past the end of a file; the file is extended to the
+        /// extent of the write, with bytes between the previous end and the start of
+        /// the write set to zero.
+        ///
+        /// In the future, this may change to take a `stream<u8, error-code>`.
+        ///
+        /// Note: This is similar to `pwrite` in POSIX.
+        write: func(
+            /// Data to write
+            buffer: list<u8>,
+            /// The offset within the file at which to write.
+            offset: filesize,
+        ) -> result<filesize, error-code>
 
-    /// Write to a descriptor, without using and updating the descriptor's offset.
-    ///
-    /// It is valid to write past the end of a file; the file is extended to the
-    /// extent of the write, with bytes between the previous end and the start of
-    /// the write set to zero.
-    ///
-    /// In the future, this may change to take a `stream<u8, error-code>`.
-    ///
-    /// Note: This is similar to `pwrite` in POSIX.
-    write: func(
-        this: descriptor,
-        /// Data to write
-        buffer: list<u8>,
-        /// The offset within the file at which to write.
-        offset: filesize,
-    ) -> result<filesize, error-code>
+        /// Read directory entries from a directory.
+        ///
+        /// On filesystems where directories contain entries referring to themselves
+        /// and their parents, often named `.` and `..` respectively, these entries
+        /// are omitted.
+        ///
+        /// This always returns a new stream which starts at the beginning of the
+        /// directory. Multiple streams may be active on the same directory, and they
+        /// do not interfere with each other.
+        read-directory: func() -> result<directory-entry-stream, error-code>
 
-    /// Read directory entries from a directory.
-    ///
-    /// On filesystems where directories contain entries referring to themselves
-    /// and their parents, often named `.` and `..` respectively, these entries
-    /// are omitted.
-    ///
-    /// This always returns a new stream which starts at the beginning of the
-    /// directory. Multiple streams may be active on the same directory, and they
-    /// do not interfere with each other.
-    read-directory: func(
-        this: descriptor
-    ) -> result<directory-entry-stream, error-code>
+        /// Synchronize the data and metadata of a file to disk.
+        ///
+        /// This function succeeds with no effect if the file descriptor is not
+        /// opened for writing.
+        ///
+        /// Note: This is similar to `fsync` in POSIX.
+        sync: func() -> result<_, error-code>
 
-    /// Synchronize the data and metadata of a file to disk.
-    ///
-    /// This function succeeds with no effect if the file descriptor is not
-    /// opened for writing.
-    ///
-    /// Note: This is similar to `fsync` in POSIX.
-    sync: func(this: descriptor) -> result<_, error-code>
+        /// Create a directory.
+        ///
+        /// Note: This is similar to `mkdirat` in POSIX.
+        create-directory-at: func(
+            /// The relative path at which to create the directory.
+            path: string,
+        ) -> result<_, error-code>
 
-    /// Create a directory.
-    ///
-    /// Note: This is similar to `mkdirat` in POSIX.
-    create-directory-at: func(
-        this: descriptor,
-        /// The relative path at which to create the directory.
-        path: string,
-    ) -> result<_, error-code>
+        /// Return the attributes of an open file or directory.
+        ///
+        /// Note: This is similar to `fstat` in POSIX, except that it does not
+        /// return device and inode information. For testing whether two
+        /// descriptors refer to the same underlying filesystem object, use
+        /// `is-same-object`. To obtain additional data that can be used do
+        /// determine whether a file has been modified, use `metadata-hash`.
+        ///
+        /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
+        stat: func() -> result<descriptor-stat, error-code>
 
-    /// Return the attributes of an open file or directory.
-    ///
-    /// Note: This is similar to `fstat` in POSIX.
-    ///
-    /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
-    stat: func(this: descriptor) -> result<descriptor-stat, error-code>
+        /// Return the attributes of a file or directory.
+        ///
+	/// Note: This is similar to `fstatat` in POSIX, except that it does
+	/// not return device and inode information. See the `stat` description
+	/// for a discussion of alternatives.
+	///
+	/// Note: This was called `path_filestat_get` in earlier versions of WASI.
+	stat-at: func(
+			/// Flags determining the method of how the path is resolved.
+			path-flags: path-flags,
+			/// The relative path of the file or directory to inspect.
+			path: string,
+		     ) -> result<descriptor-stat, error-code>
 
-    /// Return the attributes of a file or directory.
-    ///
-    /// Note: This is similar to `fstatat` in POSIX.
-    ///
-    /// Note: This was called `path_filestat_get` in earlier versions of WASI.
-    stat-at: func(
-        this: descriptor,
-        /// Flags determining the method of how the path is resolved.
-        path-flags: path-flags,
-        /// The relative path of the file or directory to inspect.
-        path: string,
-    ) -> result<descriptor-stat, error-code>
+	/// Adjust the timestamps of a file or directory.
+	///
+	/// Note: This is similar to `utimensat` in POSIX.
+	///
+	/// Note: This was called `path_filestat_set_times` in earlier versions of
+	/// WASI.
+	set-times-at: func(
+			/// Flags determining the method of how the path is resolved.
+			path-flags: path-flags,
+			/// The relative path of the file or directory to operate on.
+			path: string,
+			/// The desired values of the data access timestamp.
+			data-access-timestamp: new-timestamp,
+			/// The desired values of the data modification timestamp.
+			data-modification-timestamp: new-timestamp,
+			) -> result<_, error-code>
 
-    /// Adjust the timestamps of a file or directory.
-    ///
-    /// Note: This is similar to `utimensat` in POSIX.
-    ///
-    /// Note: This was called `path_filestat_set_times` in earlier versions of
-    /// WASI.
-    set-times-at: func(
-        this: descriptor,
-        /// Flags determining the method of how the path is resolved.
-        path-flags: path-flags,
-        /// The relative path of the file or directory to operate on.
-        path: string,
-        /// The desired values of the data access timestamp.
-        data-access-timestamp: new-timestamp,
-        /// The desired values of the data modification timestamp.
-        data-modification-timestamp: new-timestamp,
-    ) -> result<_, error-code>
+	/// Create a hard link.
+	///
+	/// Note: This is similar to `linkat` in POSIX.
+	link-at: func(
+			/// Flags determining the method of how the path is resolved.
+			old-path-flags: path-flags,
+			/// The relative source path from which to link.
+			old-path: string,
+			/// The base directory for `new-path`.
+			new-descriptor: descriptor,
+			/// The relative destination path at which to create the hard link.
+			new-path: string,
+		     ) -> result<_, error-code>
 
-    /// Create a hard link.
-    ///
-    /// Note: This is similar to `linkat` in POSIX.
-    link-at: func(
-        this: descriptor,
-        /// Flags determining the method of how the path is resolved.
-        old-path-flags: path-flags,
-        /// The relative source path from which to link.
-        old-path: string,
-        /// The base directory for `new-path`.
-        new-descriptor: descriptor,
-        /// The relative destination path at which to create the hard link.
-        new-path: string,
-    ) -> result<_, error-code>
+	/// Open a file or directory.
+	///
+	/// The returned descriptor is not guaranteed to be the lowest-numbered
+	/// descriptor not currently open/ it is randomized to prevent applications
+	/// from depending on making assumptions about indexes, since this is
+	/// error-prone in multi-threaded contexts. The returned descriptor is
+	/// guaranteed to be less than 2**31.
+	///
+	/// If `flags` contains `descriptor-flags::mutate-directory`, and the base
+	/// descriptor doesn't have `descriptor-flags::mutate-directory` set,
+	/// `open-at` fails with `error-code::read-only`.
+	///
+	/// If `flags` contains `write` or `mutate-directory`, or `open-flags`
+	/// contains `truncate` or `create`, and the base descriptor doesn't have
+	/// `descriptor-flags::mutate-directory` set, `open-at` fails with
+	/// `error-code::read-only`.
+	///
+	/// Note: This is similar to `openat` in POSIX.
+	open-at: func(
+			/// Flags determining the method of how the path is resolved.
+			path-flags: path-flags,
+			/// The relative path of the object to open.
+			path: string,
+			/// The method by which to open the file.
+			open-flags: open-flags,
+			/// Flags to use for the resulting descriptor.
+			%flags: descriptor-flags,
+			/// Permissions to use when creating a new file.
+			modes: modes
+		     ) -> result<descriptor, error-code>
 
-    /// Open a file or directory.
-    ///
-    /// The returned descriptor is not guaranteed to be the lowest-numbered
-    /// descriptor not currently open/ it is randomized to prevent applications
-    /// from depending on making assumptions about indexes, since this is
-    /// error-prone in multi-threaded contexts. The returned descriptor is
-    /// guaranteed to be less than 2**31.
-    ///
-    /// If `flags` contains `descriptor-flags::mutate-directory`, and the base
-    /// descriptor doesn't have `descriptor-flags::mutate-directory` set,
-    /// `open-at` fails with `error-code::read-only`.
-    ///
-    /// If `flags` contains `write` or `mutate-directory`, or `open-flags`
-    /// contains `truncate` or `create`, and the base descriptor doesn't have
-    /// `descriptor-flags::mutate-directory` set, `open-at` fails with
-    /// `error-code::read-only`.
-    ///
-    /// Note: This is similar to `openat` in POSIX.
-    open-at: func(
-        this: descriptor,
-        /// Flags determining the method of how the path is resolved.
-        path-flags: path-flags,
-        /// The relative path of the object to open.
-        path: string,
-        /// The method by which to open the file.
-        open-flags: open-flags,
-        /// Flags to use for the resulting descriptor.
-        %flags: descriptor-flags,
-        /// Permissions to use when creating a new file.
-        modes: modes
-    ) -> result<descriptor, error-code>
+	/// Read the contents of a symbolic link.
+	///
+	/// If the contents contain an absolute or rooted path in the underlying
+	/// filesystem, this function fails with `error-code::not-permitted`.
+	///
+	/// Note: This is similar to `readlinkat` in POSIX.
+	readlink-at: func(
+			/// The relative path of the symbolic link from which to read.
+			path: string,
+			) -> result<string, error-code>
 
-    /// Read the contents of a symbolic link.
-    ///
-    /// If the contents contain an absolute or rooted path in the underlying
-    /// filesystem, this function fails with `error-code::not-permitted`.
-    ///
-    /// Note: This is similar to `readlinkat` in POSIX.
-    readlink-at: func(
-        this: descriptor,
-        /// The relative path of the symbolic link from which to read.
-        path: string,
-    ) -> result<string, error-code>
+	/// Remove a directory.
+	///
+	/// Return `error-code::not-empty` if the directory is not empty.
+	///
+	/// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
+	remove-directory-at: func(
+			/// The relative path to a directory to remove.
+			path: string,
+			) -> result<_, error-code>
 
-    /// Remove a directory.
-    ///
-    /// Return `error-code::not-empty` if the directory is not empty.
-    ///
-    /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
-    remove-directory-at: func(
-        this: descriptor,
-        /// The relative path to a directory to remove.
-        path: string,
-    ) -> result<_, error-code>
+	/// Rename a filesystem object.
+	///
+	/// Note: This is similar to `renameat` in POSIX.
+	rename-at: func(
+			/// The relative source path of the file or directory to rename.
+			old-path: string,
+			/// The base directory for `new-path`.
+			new-descriptor: descriptor,
+			/// The relative destination path to which to rename the file or directory.
+			new-path: string,
+		       ) -> result<_, error-code>
 
-    /// Rename a filesystem object.
-    ///
-    /// Note: This is similar to `renameat` in POSIX.
-    rename-at: func(
-        this: descriptor,
-        /// The relative source path of the file or directory to rename.
-        old-path: string,
-        /// The base directory for `new-path`.
-        new-descriptor: descriptor,
-        /// The relative destination path to which to rename the file or directory.
-        new-path: string,
-    ) -> result<_, error-code>
+	/// Create a symbolic link (also known as a "symlink").
+	///
+	/// If `old-path` starts with `/`, the function fails with
+	/// `error-code::not-permitted`.
+	///
+	/// Note: This is similar to `symlinkat` in POSIX.
+	symlink-at: func(
+			/// The contents of the symbolic link.
+			old-path: string,
+			/// The relative destination path at which to create the symbolic link.
+			new-path: string,
+			) -> result<_, error-code>
 
-    /// Create a symbolic link (also known as a "symlink").
-    ///
-    /// If `old-path` starts with `/`, the function fails with
-    /// `error-code::not-permitted`.
-    ///
-    /// Note: This is similar to `symlinkat` in POSIX.
-    symlink-at: func(
-        this: descriptor,
-        /// The contents of the symbolic link.
-        old-path: string,
-        /// The relative destination path at which to create the symbolic link.
-        new-path: string,
-    ) -> result<_, error-code>
+	/// Check accessibility of a filesystem path.
+	///
+	/// Check whether the given filesystem path names an object which is
+	/// readable, writable, or executable, or whether it exists.
+	///
+	/// This does not a guarantee that subsequent accesses will succeed, as
+	/// filesystem permissions may be modified asynchronously by external
+	/// entities.
+	///
+	/// Note: This is similar to `faccessat` with the `AT_EACCESS` flag in POSIX.
+	access-at: func(
+			/// Flags determining the method of how the path is resolved.
+			path-flags: path-flags,
+			/// The relative path to check.
+			path: string,
+			/// The type of check to perform.
+			%type: access-type
+		       ) -> result<_, error-code>
 
-    /// Check accessibility of a filesystem path.
-    ///
-    /// Check whether the given filesystem path names an object which is
-    /// readable, writable, or executable, or whether it exists.
-    ///
-    /// This does not a guarantee that subsequent accesses will succeed, as
-    /// filesystem permissions may be modified asynchronously by external
-    /// entities.
-    ///
-    /// Note: This is similar to `faccessat` with the `AT_EACCESS` flag in POSIX.
-    access-at: func(
-        this: descriptor,
-        /// Flags determining the method of how the path is resolved.
-        path-flags: path-flags,
-        /// The relative path to check.
-        path: string,
-        /// The type of check to perform.
-        %type: access-type
-    ) -> result<_, error-code>
+	/// Unlink a filesystem object that is not a directory.
+	///
+	/// Return `error-code::is-directory` if the path refers to a directory.
+	/// Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
+	unlink-file-at: func(
+			/// The relative path to a file to unlink.
+			path: string,
+			) -> result<_, error-code>
 
-    /// Unlink a filesystem object that is not a directory.
-    ///
-    /// Return `error-code::is-directory` if the path refers to a directory.
-    /// Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
-    unlink-file-at: func(
-        this: descriptor,
-        /// The relative path to a file to unlink.
-        path: string,
-    ) -> result<_, error-code>
+	/// Change the permissions of a filesystem object that is not a directory.
+	///
+	/// Note that the ultimate meanings of these permissions is
+	/// filesystem-specific.
+	///
+	/// Note: This is similar to `fchmodat` in POSIX.
+	change-file-permissions-at: func(
+			/// Flags determining the method of how the path is resolved.
+			path-flags: path-flags,
+			/// The relative path to operate on.
+			path: string,
+			/// The new permissions for the filesystem object.
+			modes: modes,
+			) -> result<_, error-code>
 
-    /// Change the permissions of a filesystem object that is not a directory.
-    ///
-    /// Note that the ultimate meanings of these permissions is
-    /// filesystem-specific.
-    ///
-    /// Note: This is similar to `fchmodat` in POSIX.
-    change-file-permissions-at: func(
-        this: descriptor,
-        /// Flags determining the method of how the path is resolved.
-        path-flags: path-flags,
-        /// The relative path to operate on.
-        path: string,
-        /// The new permissions for the filesystem object.
-        modes: modes,
-    ) -> result<_, error-code>
+	/// Change the permissions of a directory.
+	///
+	/// Note that the ultimate meanings of these permissions is
+	/// filesystem-specific.
+	///
+	/// Unlike in POSIX, the `executable` flag is not reinterpreted as a "search"
+	/// flag. `read` on a directory implies readability and searchability, and
+	/// `execute` is not valid for directories.
+	///
+	/// Note: This is similar to `fchmodat` in POSIX.
+	change-directory-permissions-at: func(
+			/// Flags determining the method of how the path is resolved.
+			path-flags: path-flags,
+			/// The relative path to operate on.
+			path: string,
+			/// The new permissions for the directory.
+			modes: modes,
+			) -> result<_, error-code>
 
-    /// Change the permissions of a directory.
-    ///
-    /// Note that the ultimate meanings of these permissions is
-    /// filesystem-specific.
-    ///
-    /// Unlike in POSIX, the `executable` flag is not reinterpreted as a "search"
-    /// flag. `read` on a directory implies readability and searchability, and
-    /// `execute` is not valid for directories.
-    ///
-    /// Note: This is similar to `fchmodat` in POSIX.
-    change-directory-permissions-at: func(
-        this: descriptor,
-        /// Flags determining the method of how the path is resolved.
-        path-flags: path-flags,
-        /// The relative path to operate on.
-        path: string,
-        /// The new permissions for the directory.
-        modes: modes,
-    ) -> result<_, error-code>
+	/// Request a shared advisory lock for an open file.
+	///
+	/// This requests a *shared* lock; more than one shared lock can be held for
+	/// a file at the same time.
+	///
+	/// If the open file has an exclusive lock, this function downgrades the lock
+	/// to a shared lock. If it has a shared lock, this function has no effect.
+	///
+	/// This requests an *advisory* lock, meaning that the file could be accessed
+	/// by other programs that don't hold the lock.
+	///
+	/// It is unspecified how shared locks interact with locks acquired by
+	/// non-WASI programs.
+	///
+	/// This function blocks until the lock can be acquired.
+	///
+	/// Not all filesystems support locking; on filesystems which don't support
+	/// locking, this function returns `error-code::unsupported`.
+	///
+	/// Note: This is similar to `flock(fd, LOCK_SH)` in Unix.
+	lock-shared: func() -> result<_, error-code>
 
-    /// Request a shared advisory lock for an open file.
-    ///
-    /// This requests a *shared* lock; more than one shared lock can be held for
-    /// a file at the same time.
-    ///
-    /// If the open file has an exclusive lock, this function downgrades the lock
-    /// to a shared lock. If it has a shared lock, this function has no effect.
-    ///
-    /// This requests an *advisory* lock, meaning that the file could be accessed
-    /// by other programs that don't hold the lock.
-    ///
-    /// It is unspecified how shared locks interact with locks acquired by
-    /// non-WASI programs.
-    ///
-    /// This function blocks until the lock can be acquired.
-    ///
-    /// Not all filesystems support locking; on filesystems which don't support
-    /// locking, this function returns `error-code::unsupported`.
-    ///
-    /// Note: This is similar to `flock(fd, LOCK_SH)` in Unix.
-    lock-shared: func(this: descriptor) -> result<_, error-code>
+	/// Request an exclusive advisory lock for an open file.
+	///
+	/// This requests an *exclusive* lock; no other locks may be held for the
+	/// file while an exclusive lock is held.
+	///
+	/// If the open file has a shared lock and there are no exclusive locks held
+	/// for the file, this function upgrades the lock to an exclusive lock. If the
+	/// open file already has an exclusive lock, this function has no effect.
+	///
+	/// This requests an *advisory* lock, meaning that the file could be accessed
+	/// by other programs that don't hold the lock.
+	///
+	/// It is unspecified whether this function succeeds if the file descriptor
+	/// is not opened for writing. It is unspecified how exclusive locks interact
+	/// with locks acquired by non-WASI programs.
+	///
+	/// This function blocks until the lock can be acquired.
+	///
+	/// Not all filesystems support locking; on filesystems which don't support
+	/// locking, this function returns `error-code::unsupported`.
+	///
+	/// Note: This is similar to `flock(fd, LOCK_EX)` in Unix.
+	lock-exclusive: func() -> result<_, error-code>
 
-    /// Request an exclusive advisory lock for an open file.
-    ///
-    /// This requests an *exclusive* lock; no other locks may be held for the
-    /// file while an exclusive lock is held.
-    ///
-    /// If the open file has a shared lock and there are no exclusive locks held
-    /// for the file, this function upgrades the lock to an exclusive lock. If the
-    /// open file already has an exclusive lock, this function has no effect.
-    ///
-    /// This requests an *advisory* lock, meaning that the file could be accessed
-    /// by other programs that don't hold the lock.
-    ///
-    /// It is unspecified whether this function succeeds if the file descriptor
-    /// is not opened for writing. It is unspecified how exclusive locks interact
-    /// with locks acquired by non-WASI programs.
-    ///
-    /// This function blocks until the lock can be acquired.
-    ///
-    /// Not all filesystems support locking; on filesystems which don't support
-    /// locking, this function returns `error-code::unsupported`.
-    ///
-    /// Note: This is similar to `flock(fd, LOCK_EX)` in Unix.
-    lock-exclusive: func(this: descriptor) -> result<_, error-code>
+	/// Request a shared advisory lock for an open file.
+	///
+	/// This requests a *shared* lock; more than one shared lock can be held for
+	/// a file at the same time.
+	///
+	/// If the open file has an exclusive lock, this function downgrades the lock
+	/// to a shared lock. If it has a shared lock, this function has no effect.
+	///
+	/// This requests an *advisory* lock, meaning that the file could be accessed
+	/// by other programs that don't hold the lock.
+	///
+	/// It is unspecified how shared locks interact with locks acquired by
+	/// non-WASI programs.
+	///
+	/// This function returns `error-code::would-block` if the lock cannot be
+	/// acquired.
+	///
+	/// Not all filesystems support locking; on filesystems which don't support
+	/// locking, this function returns `error-code::unsupported`.
+	///
+	/// Note: This is similar to `flock(fd, LOCK_SH | LOCK_NB)` in Unix.
+	try-lock-shared: func() -> result<_, error-code>
 
-    /// Request a shared advisory lock for an open file.
-    ///
-    /// This requests a *shared* lock; more than one shared lock can be held for
-    /// a file at the same time.
-    ///
-    /// If the open file has an exclusive lock, this function downgrades the lock
-    /// to a shared lock. If it has a shared lock, this function has no effect.
-    ///
-    /// This requests an *advisory* lock, meaning that the file could be accessed
-    /// by other programs that don't hold the lock.
-    ///
-    /// It is unspecified how shared locks interact with locks acquired by
-    /// non-WASI programs.
-    ///
-    /// This function returns `error-code::would-block` if the lock cannot be
-    /// acquired.
-    ///
-    /// Not all filesystems support locking; on filesystems which don't support
-    /// locking, this function returns `error-code::unsupported`.
-    ///
-    /// Note: This is similar to `flock(fd, LOCK_SH | LOCK_NB)` in Unix.
-    try-lock-shared: func(this: descriptor) -> result<_, error-code>
+	/// Request an exclusive advisory lock for an open file.
+	///
+	/// This requests an *exclusive* lock; no other locks may be held for the
+	/// file while an exclusive lock is held.
+	///
+	/// If the open file has a shared lock and there are no exclusive locks held
+	/// for the file, this function upgrades the lock to an exclusive lock. If the
+	/// open file already has an exclusive lock, this function has no effect.
+	///
+	/// This requests an *advisory* lock, meaning that the file could be accessed
+	/// by other programs that don't hold the lock.
+	///
+	/// It is unspecified whether this function succeeds if the file descriptor
+	/// is not opened for writing. It is unspecified how exclusive locks interact
+	/// with locks acquired by non-WASI programs.
+	///
+	/// This function returns `error-code::would-block` if the lock cannot be
+	/// acquired.
+	///
+	/// Not all filesystems support locking; on filesystems which don't support
+	/// locking, this function returns `error-code::unsupported`.
+	///
+	/// Note: This is similar to `flock(fd, LOCK_EX | LOCK_NB)` in Unix.
+	try-lock-exclusive: func() -> result<_, error-code>
 
-    /// Request an exclusive advisory lock for an open file.
-    ///
-    /// This requests an *exclusive* lock; no other locks may be held for the
-    /// file while an exclusive lock is held.
-    ///
-    /// If the open file has a shared lock and there are no exclusive locks held
-    /// for the file, this function upgrades the lock to an exclusive lock. If the
-    /// open file already has an exclusive lock, this function has no effect.
-    ///
-    /// This requests an *advisory* lock, meaning that the file could be accessed
-    /// by other programs that don't hold the lock.
-    ///
-    /// It is unspecified whether this function succeeds if the file descriptor
-    /// is not opened for writing. It is unspecified how exclusive locks interact
-    /// with locks acquired by non-WASI programs.
-    ///
-    /// This function returns `error-code::would-block` if the lock cannot be
-    /// acquired.
-    ///
-    /// Not all filesystems support locking; on filesystems which don't support
-    /// locking, this function returns `error-code::unsupported`.
-    ///
-    /// Note: This is similar to `flock(fd, LOCK_EX | LOCK_NB)` in Unix.
-    try-lock-exclusive: func(this: descriptor) -> result<_, error-code>
+	/// Release a shared or exclusive lock on an open file.
+	///
+	/// Note: This is similar to `flock(fd, LOCK_UN)` in Unix.
+	unlock: func() -> result<_, error-code>
 
-    /// Release a shared or exclusive lock on an open file.
-    ///
-    /// Note: This is similar to `flock(fd, LOCK_UN)` in Unix.
-    unlock: func(this: descriptor) -> result<_, error-code>
+	/// Test whether two descriptors refer to the same filesystem object.
+	///
+	/// In POSIX, this corresponds to testing whether the two descriptors have the
+	/// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
+	/// wasi-filesystem does not expose device and inode numbers, so this function
+	/// may be used instead.
+	is-same-object: func(other: descriptor) -> bool
 
-    /// Dispose of the specified `descriptor`, after which it may no longer
-    /// be used.
-    drop-descriptor: func(this: descriptor)
+	/// Return a hash of the metadata associated with a filesystem object referred
+	/// to by a descriptor.
+	///
+	/// This returns a hash of the last-modification timestamp and file size, and
+	/// may also include the inode number, device number, birth timestamp, and
+	/// other metadata fields that may change when the file is modified or
+	/// replaced. It may also include a secret value chosen by the
+	/// implementation and not otherwise exposed.
+	///
+	/// Implementations are encourated to provide the following properties:
+	///
+	///  - If the file is not modified or replaced, the computed hash value should
+	///    usually not change.
+	///  - If the object is modified or replaced, the computed hash value should
+	///    usually change.
+	///  - The inputs to the hash should not be easily computable from the
+	///    computed hash.
+	///
+	/// However, none of these is required.
+	metadata-hash: func() -> result<metadata-hash-value, error-code>
+
+	/// Return a hash of the metadata associated with a filesystem object referred
+	/// to by a directory descriptor and a relative path.
+	///
+	/// This performs the same hash computation as `metadata-hash`.
+	metadata-hash-at: func(
+			    /// Flags determining the method of how the path is resolved.
+			    path-flags: path-flags,
+			    /// The relative path of the file or directory to inspect.
+			    path: string,
+	) -> result<metadata-hash-value, error-code>
+    }
 
     /// A stream of directory entries.
     ///
     /// This [represents a stream of `dir-entry`](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Streams).
-    type directory-entry-stream = u32
-
-    /// Read a single directory entry from a `directory-entry-stream`.
-    read-directory-entry: func(
-        this: directory-entry-stream
-    ) -> result<option<directory-entry>, error-code>
-
-    /// Dispose of the specified `directory-entry-stream`, after which it may no longer
-    /// be used.
-    drop-directory-entry-stream: func(this: directory-entry-stream)
+    resource directory-entry-stream {
+        /// Read a single directory entry from a `directory-entry-stream`.
+        read-directory-entry: func() -> result<option<directory-entry>, error-code>
+    }
 }

--- a/wit/deps/filesystem/world.wit
+++ b/wit/deps/filesystem/world.wit
@@ -2,4 +2,5 @@ package wasi:filesystem
 
 world example-world {
     import types
+    import preopens
 }

--- a/wit/deps/io/streams.wit
+++ b/wit/deps/io/streams.wit
@@ -10,8 +10,20 @@ interface streams {
     /// doesn't provide any additional information.
     record stream-error {}
 
-    /// An input bytestream. In the future, this will be replaced by handle
-    /// types.
+    /// Streams provide a sequence of data and then end; once they end, they
+    /// no longer provide any further data.
+    ///
+    /// For example, a stream reading from a file ends when the stream reaches
+    /// the end of the file. For another example, a stream reading from a
+    /// socket ends when the socket is closed.
+    enum stream-status {
+        /// The stream is open and may produce further data.
+        open,
+        /// The stream has ended and will not produce any further data.
+        ended,
+    }
+
+    /// An input bytestream.
     ///
     /// This conceptually represents a `stream<u8, _>`. It's temporary
     /// scaffolding until component-model's async features are ready.
@@ -22,86 +34,72 @@ interface streams {
     /// available, which could even be zero. To wait for data to be available,
     /// use the `subscribe-to-input-stream` function to obtain a `pollable` which
     /// can be polled for using `wasi_poll`.
-    ///
-    /// And at present, it is a `u32` instead of being an actual handle, until
-    /// the wit-bindgen implementation of handles and resources is ready.
-    ///
-    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
-    type input-stream = u32
+    resource input-stream {
+        /// Read bytes from a stream.
+        ///
+        /// This function returns a list of bytes containing the data that was
+        /// read, along with a `stream-status` which indicates whether the end of
+        /// the stream was reached. The returned list will contain up to `len`
+        /// bytes; it may return fewer than requested, but not more.
+        ///
+        /// Once a stream has reached the end, subsequent calls to read or
+        /// `skip` will always report end-of-stream rather than producing more
+        /// data.
+        ///
+        /// If `len` is 0, it represents a request to read 0 bytes, which should
+        /// always succeed, assuming the stream hasn't reached its end yet, and
+        /// return an empty list.
+        ///
+        /// The len here is a `u64`, but some callees may not be able to allocate
+        /// a buffer as large as that would imply.
+        /// FIXME: describe what happens if allocation fails.
+        read: func(
+            /// The maximum number of bytes to read
+            len: u64
+        ) -> result<tuple<list<u8>, stream-status>, stream-error>
 
-    /// Read bytes from a stream.
-    ///
-    /// This function returns a list of bytes containing the data that was
-    /// read, along with a bool which, when true, indicates that the end of the
-    /// stream was reached. The returned list will contain up to `len` bytes; it
-    /// may return fewer than requested, but not more.
-    ///
-    /// Once a stream has reached the end, subsequent calls to read or
-    /// `skip` will always report end-of-stream rather than producing more
-    /// data.
-    ///
-    /// If `len` is 0, it represents a request to read 0 bytes, which should
-    /// always succeed, assuming the stream hasn't reached its end yet, and
-    /// return an empty list.
-    ///
-    /// The len here is a `u64`, but some callees may not be able to allocate
-    /// a buffer as large as that would imply.
-    /// FIXME: describe what happens if allocation fails.
-    read: func(
-        this: input-stream,
-        /// The maximum number of bytes to read
-        len: u64
-    ) -> result<tuple<list<u8>, bool>, stream-error>
+        /// Read bytes from a stream, with blocking.
+        ///
+        /// This is similar to `read`, except that it blocks until at least one
+        /// byte can be read.
+        blocking-read: func(
+            /// The maximum number of bytes to read
+            len: u64
+        ) -> result<tuple<list<u8>, stream-status>, stream-error>
 
-    /// Read bytes from a stream, with blocking.
-    ///
-    /// This is similar to `read`, except that it blocks until at least one
-    /// byte can be read.
-    blocking-read: func(
-        this: input-stream,
-        /// The maximum number of bytes to read
-        len: u64
-    ) -> result<tuple<list<u8>, bool>, stream-error>
+        /// Skip bytes from a stream.
+        ///
+        /// This is similar to the `read` function, but avoids copying the
+        /// bytes into the instance.
+        ///
+        /// Once a stream has reached the end, subsequent calls to read or
+        /// `skip` will always report end-of-stream rather than producing more
+        /// data.
+        ///
+        /// This function returns the number of bytes skipped, along with a
+        /// `stream-status` indicating whether the end of the stream was
+        /// reached. The returned value will be at most `len`; it may be less.
+        skip: func(
+            /// The maximum number of bytes to skip.
+            len: u64,
+        ) -> result<tuple<u64, stream-status>, stream-error>
 
-    /// Skip bytes from a stream.
-    ///
-    /// This is similar to the `read` function, but avoids copying the
-    /// bytes into the instance.
-    ///
-    /// Once a stream has reached the end, subsequent calls to read or
-    /// `skip` will always report end-of-stream rather than producing more
-    /// data.
-    ///
-    /// This function returns the number of bytes skipped, along with a bool
-    /// indicating whether the end of the stream was reached. The returned
-    /// value will be at most `len`; it may be less.
-    skip: func(
-        this: input-stream,
-        /// The maximum number of bytes to skip.
-        len: u64,
-    ) -> result<tuple<u64, bool>, stream-error>
+        /// Skip bytes from a stream, with blocking.
+        ///
+        /// This is similar to `skip`, except that it blocks until at least one
+        /// byte can be consumed.
+        blocking-skip: func(
+            /// The maximum number of bytes to skip.
+            len: u64,
+        ) -> result<tuple<u64, stream-status>, stream-error>
 
-    /// Skip bytes from a stream, with blocking.
-    ///
-    /// This is similar to `skip`, except that it blocks until at least one
-    /// byte can be consumed.
-    blocking-skip: func(
-        this: input-stream,
-        /// The maximum number of bytes to skip.
-        len: u64,
-    ) -> result<tuple<u64, bool>, stream-error>
+        /// Create a `pollable` which will resolve once either the specified stream
+        /// has bytes available to read or the other end of the stream has been
+        /// closed.
+        subscribe-to-input-stream: func() -> pollable
+    }
 
-    /// Create a `pollable` which will resolve once either the specified stream
-    /// has bytes available to read or the other end of the stream has been
-    /// closed.
-    subscribe-to-input-stream: func(this: input-stream) -> pollable
-
-    /// Dispose of the specified `input-stream`, after which it may no longer
-    /// be used.
-    drop-input-stream: func(this: input-stream)
-
-    /// An output bytestream. In the future, this will be replaced by handle
-    /// types.
+    /// An output bytestream.
     ///
     /// This conceptually represents a `stream<u8, _>`. It's temporary
     /// scaffolding until component-model's async features are ready.
@@ -112,102 +110,86 @@ interface streams {
     /// promptly, which could even be zero. To wait for the stream to be ready to
     /// accept data, the `subscribe-to-output-stream` function to obtain a
     /// `pollable` which can be polled for using `wasi_poll`.
-    ///
-    /// And at present, it is a `u32` instead of being an actual handle, until
-    /// the wit-bindgen implementation of handles and resources is ready.
-    ///
-    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
-    type output-stream = u32
+    resource output-stream {
+        /// Write bytes to a stream.
+        ///
+        /// This function returns a `u64` indicating the number of bytes from
+        /// `buf` that were written; it may be less than the full list.
+        write: func(
+            /// Data to write
+            buf: list<u8>
+        ) -> result<u64, stream-error>
 
-    /// Write bytes to a stream.
-    ///
-    /// This function returns a `u64` indicating the number of bytes from
-    /// `buf` that were written; it may be less than the full list.
-    write: func(
-        this: output-stream,
-        /// Data to write
-        buf: list<u8>
-    ) -> result<u64, stream-error>
+        /// Write bytes to a stream, with blocking.
+        ///
+        /// This is similar to `write`, except that it blocks until at least one
+        /// byte can be written.
+        blocking-write: func(
+            /// Data to write
+            buf: list<u8>
+        ) -> result<u64, stream-error>
 
-    /// Write bytes to a stream, with blocking.
-    ///
-    /// This is similar to `write`, except that it blocks until at least one
-    /// byte can be written.
-    blocking-write: func(
-        this: output-stream,
-        /// Data to write
-        buf: list<u8>
-    ) -> result<u64, stream-error>
+        /// Write multiple zero bytes to a stream.
+        ///
+        /// This function returns a `u64` indicating the number of zero bytes
+        /// that were written; it may be less than `len`.
+        write-zeroes: func(
+            /// The number of zero bytes to write
+            len: u64
+        ) -> result<u64, stream-error>
 
-    /// Write multiple zero bytes to a stream.
-    ///
-    /// This function returns a `u64` indicating the number of zero bytes
-    /// that were written; it may be less than `len`.
-    write-zeroes: func(
-        this: output-stream,
-        /// The number of zero bytes to write
-        len: u64
-    ) -> result<u64, stream-error>
+        /// Write multiple zero bytes to a stream, with blocking.
+        ///
+        /// This is similar to `write-zeroes`, except that it blocks until at least
+        /// one byte can be written.
+        blocking-write-zeroes: func(
+            /// The number of zero bytes to write
+            len: u64
+        ) -> result<u64, stream-error>
 
-    /// Write multiple zero bytes to a stream, with blocking.
-    ///
-    /// This is similar to `write-zeroes`, except that it blocks until at least
-    /// one byte can be written.
-    blocking-write-zeroes: func(
-        this: output-stream,
-        /// The number of zero bytes to write
-        len: u64
-    ) -> result<u64, stream-error>
+        /// Read from one stream and write to another.
+        ///
+        /// This function returns the number of bytes transferred; it may be less
+        /// than `len`.
+        ///
+        /// Unlike other I/O functions, this function blocks until all the data
+        /// read from the input stream has been written to the output stream.
+        splice: func(
+            /// The stream to read from
+            src: input-stream,
+            /// The number of bytes to splice
+            len: u64,
+        ) -> result<tuple<u64, stream-status>, stream-error>
 
-    /// Read from one stream and write to another.
-    ///
-    /// This function returns the number of bytes transferred; it may be less
-    /// than `len`.
-    ///
-    /// Unlike other I/O functions, this function blocks until all the data
-    /// read from the input stream has been written to the output stream.
-    splice: func(
-        this: output-stream,
-        /// The stream to read from
-        src: input-stream,
-        /// The number of bytes to splice
-        len: u64,
-    ) -> result<tuple<u64, bool>, stream-error>
+        /// Read from one stream and write to another, with blocking.
+        ///
+        /// This is similar to `splice`, except that it blocks until at least
+        /// one byte can be read.
+        blocking-splice: func(
+            /// The stream to read from
+            src: input-stream,
+            /// The number of bytes to splice
+            len: u64,
+        ) -> result<tuple<u64, stream-status>, stream-error>
 
-    /// Read from one stream and write to another, with blocking.
-    ///
-    /// This is similar to `splice`, except that it blocks until at least
-    /// one byte can be read.
-    blocking-splice: func(
-        this: output-stream,
-        /// The stream to read from
-        src: input-stream,
-        /// The number of bytes to splice
-        len: u64,
-    ) -> result<tuple<u64, bool>, stream-error>
+        /// Forward the entire contents of an input stream to an output stream.
+        ///
+        /// This function repeatedly reads from the input stream and writes
+        /// the data to the output stream, until the end of the input stream
+        /// is reached, or an error is encountered.
+        ///
+        /// Unlike other I/O functions, this function blocks until the end
+        /// of the input stream is seen and all the data has been written to
+        /// the output stream.
+        ///
+        /// This function returns the number of bytes transferred.
+        forward: func(
+            /// The stream to read from
+            src: input-stream
+        ) -> result<u64, stream-error>
 
-    /// Forward the entire contents of an input stream to an output stream.
-    ///
-    /// This function repeatedly reads from the input stream and writes
-    /// the data to the output stream, until the end of the input stream
-    /// is reached, or an error is encountered.
-    ///
-    /// Unlike other I/O functions, this function blocks until the end
-    /// of the input stream is seen and all the data has been written to
-    /// the output stream.
-    ///
-    /// This function returns the number of bytes transferred.
-    forward: func(
-        this: output-stream,
-        /// The stream to read from
-        src: input-stream
-    ) -> result<u64, stream-error>
-
-    /// Create a `pollable` which will resolve once either the specified stream
-    /// is ready to accept bytes or the other end of the stream has been closed.
-    subscribe-to-output-stream: func(this: output-stream) -> pollable
-
-    /// Dispose of the specified `output-stream`, after which it may no longer
-    /// be used.
-    drop-output-stream: func(this: output-stream)
+        /// Create a `pollable` which will resolve once either the specified stream
+        /// is ready to accept bytes or the other end of the stream has been closed.
+        subscribe-to-output-stream: func() -> pollable
+    }
 }

--- a/wit/deps/poll/poll.wit
+++ b/wit/deps/poll/poll.wit
@@ -2,26 +2,25 @@
 /// at once.
 interface poll {
     /// A "pollable" handle.
-    ///
-    /// This is conceptually represents a `stream<_, _>`, or in other words,
-    /// a stream that one can wait on, repeatedly, but which does not itself
-    /// produce any data. It's temporary scaffolding until component-model's
-    /// async features are ready.
-    ///
-    /// And at present, it is a `u32` instead of being an actual handle, until
-    /// the wit-bindgen implementation of handles and resources is ready.
-    ///
-    /// `pollable` lifetimes are not automatically managed. Users must ensure
-    /// that they do not outlive the resource they reference.
-    ///
-    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
-    type pollable = u32
-
-    /// Dispose of the specified `pollable`, after which it may no longer
-    /// be used.
-    drop-pollable: func(this: pollable)
+    resource pollable
 
     /// Poll for completion on a set of pollables.
+    ///
+    /// This function takes a list of pollables, which identify I/O sources of
+    /// interest, and waits until one or more of the events is ready for I/O.
+    ///
+    /// The result `list<bool>` is the same length as the argument
+    /// `list<pollable>`, and indicates the readiness of each corresponding
+    /// element in that list, with true indicating ready. A single call can
+    /// return multiple true elements.
+    ///
+    /// A timeout can be implemented by adding a pollable from the
+    /// wasi-clocks API to the list.
+    ///
+    /// This function does not return a `result`; polling in itself does not
+    /// do any I/O so it doesn't fail. If any of the I/O sources identified by
+    /// the pollables has an error, it is indicated by marking the source as
+    /// ready in the `list<bool>`.
     ///
     /// The "oneoff" in the name refers to the fact that this function must do a
     /// linear scan through the entire list of subscriptions, which may be
@@ -29,11 +28,5 @@ interface poll {
     /// many times. In the future, this is expected to be obsoleted by the
     /// component model async proposal, which will include a scalable waiting
     /// facility.
-    ///
-    /// Note that the return type would ideally be `list<bool>`, but that would
-    /// be more difficult to polyfill given the current state of `wit-bindgen`.
-    /// See <https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061>
-    /// for details.  For now, we use zero to mean "not ready" and non-zero to
-    /// mean "ready".
-    poll-oneoff: func(in: list<pollable>) -> list<u8>
+    poll-oneoff: func(in: list<pollable>) -> list<bool>
 }

--- a/wit/deps/sockets/ip-name-lookup.wit
+++ b/wit/deps/sockets/ip-name-lookup.wit
@@ -38,14 +38,12 @@ interface ip-name-lookup {
 
 
 
-    type resolve-address-stream = u32
-
+    resource resolve-address-stream {
 	/// Returns the next address from the resolver.
 	/// 
 	/// This function should be called multiple times. On each call, it will
 	/// return the next address in connection order preference. If all
 	/// addresses have been exhausted, this function returns `none`.
-	/// After which, you should release the stream with `drop-resolve-address-stream`.
 	/// 
 	/// This function never returns IPv4-mapped IPv6 addresses.
 	/// 
@@ -54,16 +52,12 @@ interface ip-name-lookup {
 	/// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
 	/// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
 	/// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
-	resolve-next-address: func(this: resolve-address-stream) -> result<option<ip-address>, error-code>
-
-	/// Dispose of the specified `resolve-address-stream`, after which it may no longer be used.
-	/// 
-	/// Note: this function is scheduled to be removed when Resources are natively supported in Wit.
-	drop-resolve-address-stream: func(this: resolve-address-stream)
+	resolve-next-address: func() -> result<option<ip-address>, error-code>
 
 	/// Create a `pollable` which will resolve once the stream is ready for I/O.
 	/// 
 	/// Note: this function is here for WASI Preview2 only.
 	/// It's planned to be removed when `future` is natively supported in Preview3.
-	subscribe: func(this: resolve-address-stream) -> pollable
+	subscribe: func() -> pollable
+    }
 }

--- a/wit/deps/sockets/network.wit
+++ b/wit/deps/sockets/network.wit
@@ -3,15 +3,7 @@ interface network {
     /// An opaque resource that represents access to (a subset of) the network.
 	/// This enables context-based security for networking.
 	/// There is no need for this to map 1:1 to a physical network interface.
-	/// 
-	/// FYI, In the future this will be replaced by handle types.
-    type network = u32
-
-	/// Dispose of the specified `network`, after which it may no longer be used.
-	/// 
-	/// Note: this function is scheduled to be removed when Resources are natively supported in Wit.
-	drop-network: func(this: network)
-
+    resource network
 
 	/// Error codes.
 	/// 

--- a/wit/deps/sockets/tcp.wit
+++ b/wit/deps/sockets/tcp.wit
@@ -4,10 +4,6 @@ interface tcp {
 	use wasi:poll/poll.{pollable}
 	use network.{network, error-code, ip-socket-address, ip-address-family}
 
-	/// A TCP socket handle.
-	type tcp-socket = u32
-	
-
 	enum shutdown-type {
 		/// Similar to `SHUT_RD` in POSIX.
 		receive,
@@ -19,6 +15,8 @@ interface tcp {
 		both,
 	}
 
+	/// A TCP socket handle.
+	resource tcp-socket {
 
 	/// Bind the socket to a specific network on the provided IP address and port.
 	///
@@ -48,8 +46,8 @@ interface tcp {
 	/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-	start-bind: func(this: tcp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
-	finish-bind: func(this: tcp-socket) -> result<_, error-code>
+	start-bind: func(network: network, local-address: ip-socket-address) -> result<_, error-code>
+	finish-bind: func() -> result<_, error-code>
 
 	/// Connect to a remote endpoint.
 	/// 
@@ -80,8 +78,8 @@ interface tcp {
 	/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
 	/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-	start-connect: func(this: tcp-socket, network: network, remote-address: ip-socket-address) -> result<_, error-code>
-	finish-connect: func(this: tcp-socket) -> result<tuple<input-stream, output-stream>, error-code>
+	start-connect: func(network: network, remote-address: ip-socket-address) -> result<_, error-code>
+	finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>
 
 	/// Start listening for new connections.
 	/// 
@@ -107,8 +105,8 @@ interface tcp {
 	/// - <https://man7.org/linux/man-pages/man2/listen.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
-	start-listen: func(this: tcp-socket) -> result<_, error-code>
-	finish-listen: func(this: tcp-socket) -> result<_, error-code>
+	start-listen: func() -> result<_, error-code>
+	finish-listen: func() -> result<_, error-code>
 
 	/// Accept a new client socket.
 	/// 
@@ -128,7 +126,7 @@ interface tcp {
 	/// - <https://man7.org/linux/man-pages/man2/accept.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
-	accept: func(this: tcp-socket) -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>
+	accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>
 
 	/// Get the bound local address.
 	/// 
@@ -140,7 +138,7 @@ interface tcp {
 	/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
 	/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-	local-address: func(this: tcp-socket) -> result<ip-socket-address, error-code>
+	local-address: func() -> result<ip-socket-address, error-code>
 
 	/// Get the bound remote address.
 	/// 
@@ -152,12 +150,12 @@ interface tcp {
 	/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-	remote-address: func(this: tcp-socket) -> result<ip-socket-address, error-code>
+	remote-address: func() -> result<ip-socket-address, error-code>
 
 	/// Whether this is a IPv4 or IPv6 socket.
 	/// 
 	/// Equivalent to the SO_DOMAIN socket option.
-	address-family: func(this: tcp-socket) -> ip-address-family
+	address-family: func() -> ip-address-family
 	
 	/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
 	/// 
@@ -168,29 +166,29 @@ interface tcp {
 	/// - `already-bound`:        (set) The socket is already bound.
 	/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
 	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-	ipv6-only: func(this: tcp-socket) -> result<bool, error-code>
-	set-ipv6-only: func(this: tcp-socket, value: bool) -> result<_, error-code>
+	ipv6-only: func() -> result<bool, error-code>
+	set-ipv6-only: func(value: bool) -> result<_, error-code>
 
 	/// Hints the desired listen queue size. Implementations are free to ignore this.
 	/// 
 	/// # Typical errors
 	/// - `already-connected`:    (set) The socket is already in the Connection state.
 	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-	set-listen-backlog-size: func(this: tcp-socket, value: u64) -> result<_, error-code>
+	set-listen-backlog-size: func(value: u64) -> result<_, error-code>
 
 	/// Equivalent to the SO_KEEPALIVE socket option.
 	/// 
 	/// # Typical errors
 	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-	keep-alive: func(this: tcp-socket) -> result<bool, error-code>
-	set-keep-alive: func(this: tcp-socket, value: bool) -> result<_, error-code>
+	keep-alive: func() -> result<bool, error-code>
+	set-keep-alive: func(value: bool) -> result<_, error-code>
 
 	/// Equivalent to the TCP_NODELAY socket option.
 	/// 
 	/// # Typical errors
 	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-	no-delay: func(this: tcp-socket) -> result<bool, error-code>
-	set-no-delay: func(this: tcp-socket, value: bool) -> result<_, error-code>
+	no-delay: func() -> result<bool, error-code>
+	set-no-delay: func(value: bool) -> result<_, error-code>
 	
 	/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
 	/// 
@@ -198,8 +196,8 @@ interface tcp {
 	/// - `already-connected`:    (set) The socket is already in the Connection state.
 	/// - `already-listening`:    (set) The socket is already in the Listener state.
 	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-	unicast-hop-limit: func(this: tcp-socket) -> result<u8, error-code>
-	set-unicast-hop-limit: func(this: tcp-socket, value: u8) -> result<_, error-code>
+	unicast-hop-limit: func() -> result<u8, error-code>
+	set-unicast-hop-limit: func(value: u8) -> result<_, error-code>
 
 	/// The kernel buffer space reserved for sends/receives on this socket.
 	/// 
@@ -216,16 +214,16 @@ interface tcp {
 	/// - `already-connected`:    (set) The socket is already in the Connection state.
 	/// - `already-listening`:    (set) The socket is already in the Listener state.
 	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-	receive-buffer-size: func(this: tcp-socket) -> result<u64, error-code>
-	set-receive-buffer-size: func(this: tcp-socket, value: u64) -> result<_, error-code>
-	send-buffer-size: func(this: tcp-socket) -> result<u64, error-code>
-	set-send-buffer-size: func(this: tcp-socket, value: u64) -> result<_, error-code>
+	receive-buffer-size: func() -> result<u64, error-code>
+	set-receive-buffer-size: func(value: u64) -> result<_, error-code>
+	send-buffer-size: func() -> result<u64, error-code>
+	set-send-buffer-size: func(value: u64) -> result<_, error-code>
 
 	/// Create a `pollable` which will resolve once the socket is ready for I/O.
 	/// 
 	/// Note: this function is here for WASI Preview2 only.
 	/// It's planned to be removed when `future` is natively supported in Preview3.
-	subscribe: func(this: tcp-socket) -> pollable
+	subscribe: func() -> pollable
 
 	/// Initiate a graceful shutdown.
 	/// 
@@ -246,12 +244,7 @@ interface tcp {
 	/// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
-	shutdown: func(this: tcp-socket, shutdown-type: shutdown-type) -> result<_, error-code>
+	shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>
 
-	/// Dispose of the specified `tcp-socket`, after which it may no longer be used.
-	/// 
-	/// Similar to the POSIX `close` function.
-	/// 
-	/// Note: this function is scheduled to be removed when Resources are natively supported in Wit.
-	drop-tcp-socket: func(this: tcp-socket)
+	}
 }

--- a/wit/deps/sockets/udp.wit
+++ b/wit/deps/sockets/udp.wit
@@ -4,10 +4,6 @@ interface udp {
 	use network.{network, error-code, ip-socket-address, ip-address-family}
 
 
-	/// A UDP socket handle.
-	type udp-socket = u32
-
-
 	record datagram {
 		data: list<u8>, // Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
 		remote-address: ip-socket-address,
@@ -20,7 +16,8 @@ interface udp {
 		/// ecn: u2, // IP_RECVTOS
 	}
 
-
+	/// A UDP socket handle.
+	resource udp-socket {
 
 	/// Bind the socket to a specific network on the provided IP address and port.
 	///
@@ -49,8 +46,8 @@ interface udp {
 	/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-	start-bind: func(this: udp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
-	finish-bind: func(this: udp-socket) -> result<_, error-code>
+	start-bind: func(network: network, local-address: ip-socket-address) -> result<_, error-code>
+	finish-bind: func() -> result<_, error-code>
 
 	/// Set the destination address.
 	/// 
@@ -81,8 +78,8 @@ interface udp {
 	/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
 	/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-	start-connect: func(this: udp-socket, network: network, remote-address: ip-socket-address) -> result<_, error-code>
-	finish-connect: func(this: udp-socket) -> result<_, error-code>
+	start-connect: func(network: network, remote-address: ip-socket-address) -> result<_, error-code>
+	finish-connect: func() -> result<_, error-code>
 
 	/// Receive a message.
 	/// 
@@ -103,7 +100,7 @@ interface udp {
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
 	/// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
-	receive: func(this: udp-socket) -> result<datagram, error-code>
+	receive: func() -> result<datagram, error-code>
 
 	/// Send a message to a specific destination address.
 	/// 
@@ -128,7 +125,7 @@ interface udp {
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
-	send: func(this: udp-socket, datagram: datagram) -> result<_, error-code>
+	send: func(datagram: datagram) -> result<_, error-code>
 
 	/// Get the current bound address.
 	/// 
@@ -140,7 +137,7 @@ interface udp {
 	/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
 	/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-	local-address: func(this: udp-socket) -> result<ip-socket-address, error-code>
+	local-address: func() -> result<ip-socket-address, error-code>
 
 	/// Get the address set with `connect`.
 	/// 
@@ -152,12 +149,12 @@ interface udp {
 	/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-	remote-address: func(this: udp-socket) -> result<ip-socket-address, error-code>
+	remote-address: func() -> result<ip-socket-address, error-code>
 
 	/// Whether this is a IPv4 or IPv6 socket.
 	/// 
 	/// Equivalent to the SO_DOMAIN socket option.
-	address-family: func(this: udp-socket) -> ip-address-family
+	address-family: func() -> ip-address-family
 
 	/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
 	/// 
@@ -168,15 +165,15 @@ interface udp {
 	/// - `already-bound`:        (set) The socket is already bound.
 	/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
 	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
-	ipv6-only: func(this: udp-socket) -> result<bool, error-code>
-	set-ipv6-only: func(this: udp-socket, value: bool) -> result<_, error-code>
+	ipv6-only: func() -> result<bool, error-code>
+	set-ipv6-only: func(value: bool) -> result<_, error-code>
 
 	/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
 	/// 
 	/// # Typical errors
 	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
-	unicast-hop-limit: func(this: udp-socket) -> result<u8, error-code>
-	set-unicast-hop-limit: func(this: udp-socket, value: u8) -> result<_, error-code>
+	unicast-hop-limit: func() -> result<u8, error-code>
+	set-unicast-hop-limit: func(value: u8) -> result<_, error-code>
 
 	/// The kernel buffer space reserved for sends/receives on this socket.
 	/// 
@@ -193,19 +190,16 @@ interface udp {
 	/// 
 	/// # Typical errors
 	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
-	receive-buffer-size: func(this: udp-socket) -> result<u64, error-code>
-	set-receive-buffer-size: func(this: udp-socket, value: u64) -> result<_, error-code>
-	send-buffer-size: func(this: udp-socket) -> result<u64, error-code>
-	set-send-buffer-size: func(this: udp-socket, value: u64) -> result<_, error-code>
+	receive-buffer-size: func() -> result<u64, error-code>
+	set-receive-buffer-size: func(value: u64) -> result<_, error-code>
+	send-buffer-size: func() -> result<u64, error-code>
+	set-send-buffer-size: func(value: u64) -> result<_, error-code>
 
 	/// Create a `pollable` which will resolve once the socket is ready for I/O.
 	/// 
 	/// Note: this function is here for WASI Preview2 only.
 	/// It's planned to be removed when `future` is natively supported in Preview3.
-	subscribe: func(this: udp-socket) -> pollable
+	subscribe: func() -> pollable
 
-	/// Dispose of the specified `udp-socket`, after which it may no longer be used.
-	/// 
-	/// Note: this function is scheduled to be removed when Resources are natively supported in Wit.
-	drop-udp-socket: func(this: udp-socket)
+	}
 }

--- a/wit/terminal.wit
+++ b/wit/terminal.wit
@@ -1,31 +1,19 @@
 interface terminal-input {
     /// The input side of a terminal.
-    ///
-    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
-    type terminal-input = u32
-
-    // In the future, this may include functions for disabling echoing,
-    // disabling input buffering so that keyboard events are sent through
-    // immediately, querying supported features, and so on.
-
-    /// Dispose of the specified terminal-input after which it may no longer
-    /// be used.
-    drop-terminal-input: func(this: terminal-input)
+    resource terminal-input {
+        // In the future, this may include functions for disabling echoing,
+        // disabling input buffering so that keyboard events are sent through
+        // immediately, querying supported features, and so on.
+    }
 }
 
 interface terminal-output {
     /// The output side of a terminal.
-    ///
-    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
-    type terminal-output = u32
-
-    // In the future, this may include functions for querying the terminal
-    // size, being notified of terminal size changes, querying supported
-    // features, and so on.
-
-    /// Dispose of the specified terminal-output, after which it may no longer
-    /// be used.
-    drop-terminal-output: func(this: terminal-output)
+    resource terminal-output {
+        // In the future, this may include functions for querying the terminal
+        // size, being notified of terminal size changes, querying supported
+        // features, and so on.
+    }
 }
 
 /// An interface providing an optional `terminal-input` for stdin as a

--- a/wit/terminal.wit
+++ b/wit/terminal.wit
@@ -1,18 +1,277 @@
+/// Support for terminal input.
+///
+/// See the comments on the terminal-output interface for more background
+/// on terminal support.
 interface terminal-input {
     /// The input side of a terminal.
+    ///
+    /// Implementations are encouraged to reset terminals to default settings
+    /// when terminal resources are dropped.
+    ///
+    /// The full feature is not yet fully defined, however implementations
+    /// are encouraged to emit the following control codes and input sequences:
+    ///
+    /// Control codes:
+    ///
+    /// | Code | Meaning                                                      |
+    /// | -----| ------------------------------------------------------------ |
+    /// | U+8  | Ctrl-H; despite U+8 being historically called "backspace" in ASCII, this isn't the backspace key |
+    /// | U+9  | Tab                                                          |
+    /// | U+A  | Enter                                                        |
+    /// | U+C  | Ctrl-L, in immediate mode, requests applications refresh the screen |
+    /// | U+1B | Escape                                                       |
+    /// | U+7F | Backspace; this is the backspace key                         |
+    ///
+    /// Escape sequences:
+    ///
+    /// | Sequence     | Meaning                                              |
+    /// | ------------ | ---------------------------------------------------- |
+    /// | `␛[A`        | Up                                                   |
+    /// | `␛[B`        | Down                                                 |
+    /// | `␛[C`        | Right                                                |
+    /// | `␛[D`        | Left                                                 |
+    /// | `␛[F`        | End                                                  |
+    /// | `␛[H`        | Home                                                 |
+    /// | `␛[2~`       | Insert                                               |
+    /// | `␛[3~`       | Delete                                               |
+    /// | `␛[5~`       | Page Up                                              |
+    /// | `␛[6~`       | Page Down                                            |
+    /// | `␛OP`        | F1                                                   |
+    /// | `␛OQ`        | F2                                                   |
+    /// | `␛OR`        | F3                                                   |
+    /// | `␛OS`        | F4                                                   |
+    /// | `␛[15~`      | F5                                                   |
+    /// | `␛[17~`      | F6                                                   |
+    /// | `␛[18~`      | F7                                                   |
+    /// | `␛[19~`      | F8                                                   |
+    /// | `␛[20~`      | F9                                                   |
+    /// | `␛[21~`      | F10                                                  |
+    /// | `␛[23~`      | F11                                                  |
+    /// | `␛[24~`      | F12                                                  |
+    /// | `␛[200~`     | Begin Paste; only emitted when bracketed paste mode is activated |
+    /// | `␛[201~`     | End Paste; only emitted when bracketed paste mode is activated |
     resource terminal-input {
-        // In the future, this may include functions for disabling echoing,
-        // disabling input buffering so that keyboard events are sent through
-        // immediately, querying supported features, and so on.
+        /// Enable or disable *immediate* mode.
+        ///
+        /// Immediate mode makes input key sequences available to be read on
+        /// the input stream immediately, rather than buffering them up
+        /// until the end of the line is seen.
+        ///
+        /// This may fail if the implementation doesn't support immediate mode.
+        set-immediate: func(mode: bool) -> result
+
+        /// Disable or enable *echo* mode.
+        ///
+        /// Echo mode retransmits input key sequences back to the output of the
+        /// terminal, so that users can see what they're typing. Echoing is the
+        /// default behavior in terminals, but disabling can be useful for
+        /// entering passwords or for combining with immediate mode to make
+        /// interactive terminal interfaces.
+        ///
+        /// This may fail if the implementation doesn't support echo mode.
+        set-echo: func(mode: bool) -> result
     }
 }
 
+/// Support for terminal output.
+///
+/// This includes support for a basic terminal interactions, including
+/// functions for getting and setting basic "termios" terminal attributes, and
+/// support for control codes and "ANSI" escape sequences.
+///
+/// The "ANSI" here refers to ANSI X3.64, which later became ECMA-48
+/// (ISO/IEC 6429). However, ECMA-48 was last updated in 1991, it has many
+/// features which are no longer relevant, it has no awareness of Unicode
+/// or UTF-8, it leaves many behaviors implementation-dependent, and it lacks
+/// many extensions that modern implementations have added and have become
+/// popular in modern use cases. So while this "ANSI" is the original source
+/// for a lot of the terminology used, it's not a normative reference.
+///
+/// For now, out of practicality, this document starts by describing features
+/// which are widely supported and widely used in modern implementations and
+/// use cases. Over time, this could grow to become more complete.
 interface terminal-output {
+    use wasi:poll/poll.{pollable}
+
     /// The output side of a terminal.
+    ///
+    /// Terminal feature sets and behavior vary between implementations, and
+    /// this specification does not yet describe a specific set of escape
+    /// sequences or semantics, so applications are encouraged to stick to
+    /// widely-supported features.
+    ///
+    /// Implementations are encouraged to reset terminals to default settings
+    /// when terminal resources are dropped, or before writing log messages or
+    /// other output to the terminal, to prevent applications from modifying
+    /// the appearance of or reading unrelated output.
+    ///
+    /// Terminal emulators are encouraged to:
+    ///  - avoid interpreting escape sequences which cause writes to files,
+    ///    cause pre-existing terminal contents to be echoed back to the
+    ///    application, or disconnect the terminal,
+    ///  - give a visual indication, such as a terminal window title change,
+    ///    when entering and exiting full-screen mode,
+    ///  - support UTF-8,
+    ///  - recognize '␛\' as a ST (String Terminator) sequence,
+    ///  - emit `␛OP`, `␛OQ`, `␛OR`, and `␛OS` for F1-F4 keypresses, and
+    ///  - avoid interpreting the 8-bit encodings of the C1 control codes.
     resource terminal-output {
-        // In the future, this may include functions for querying the terminal
-        // size, being notified of terminal size changes, querying supported
-        // features, and so on.
+        /// Return the current number of rows and columns in the terminal.
+        ///
+        /// Not all terminals have a set size, and not all that do know their
+        /// size, so this function may fail the size cannot be determined.
+        window-size: func() -> result<rows-and-columns>
+
+        /// Return the current number of columns in the terminal.
+        ///
+        /// Not all terminals have a set size, and not all that do know their
+        /// size, so this function may fail if the size cannot be determined.
+        window-columns: func() -> result<u16>
+
+        /// Return a `pollable` listening for window size changes.
+        ///
+        /// This `pollable` can be used with `poll_oneoff` to listen for
+        /// changes to the window size. On implementations which don't
+        /// support size changes, they just never happen.
+        subscribe-to-size-changes: func() -> pollable
+
+        /// What kinds of colors are supported, and preferred?
+        ///
+        /// This returns a set of flags indicating which families of
+        /// escape sequences for displaying color are supported.
+        ///
+        /// Some terminals support "OSC 4" as a way to detect color support,
+        /// however this API is preferred.
+        color: func() -> color-flags
+
+        /// Does this terminal support line-editing features?
+        ///
+        /// These include the control codes and escape sequences for moving
+        /// the cursor around the current line, clearing all or part of the
+        /// current line, as well as the "alert" code (U+7) which should
+        /// produce an acoustic or visual notification. This reflects the
+        /// functionality commonly used for command-line prompts.
+        ///
+        /// The full feature is not yet fully defined, however implementations
+        /// advertising line-editing support are encouraged to support the
+        /// following control codes and escape sequences:
+        ///
+        /// Control codes:
+        ///
+        /// | Code | Meaning                                                  |
+        /// | ---- | -------------------------------------------------------- |
+        /// | U+7  | Alert                                                    |
+        /// | U+8  | Move cursor back one column                              |
+        /// | U+9  | Tab                                                      |
+        /// | U+A  | End of line                                              |
+        /// | U+C  | FF Terminal Compatibility                                |
+        /// | U+D  | Carriage Return                                          |
+        /// | U+7F | No Effect                                                |
+        ///
+        /// Escape sequences:
+        ///
+        /// | Sequence | Meaning                                              |
+        /// | -------- | ---------------------------------------------------- |
+        /// | `␛[K`    | Clear to end of line                                 |
+        /// | `␛[0K`   | Clear to end of line                                 |
+        /// | `␛[2K`   | Clear entire line                                    |
+        line-editing-supported: func() -> bool
+
+        /// Does this terminal support full-screen features?
+        ///
+        /// These include moving the cursor to arbitrary positions on the
+        /// full screen, and clearing all or part of the full screen.
+        /// This reflects the functionality commonly used for interactive
+        /// terminal user interfaces.
+        ///
+        /// The full feature is not yet fully defined, however implementations
+        /// advertising full-screen support are encouraged to support the
+        /// following escape sequences:
+        ///
+        /// Escape sequences:
+        ///
+        /// | Sequence    | Meaning                                           |
+        /// | ----------- | ------------------------------------------------- |
+        /// | `␛[?1049h`  | Enter full-screen mode                            |
+        ///
+        /// Escape sequences when full-screen mode has been entered:
+        ///
+        /// | Sequence    | Meaning                                           |
+        /// | ----------- | ------------------------------------------------- |
+        /// | `␛[«n»A`    | Move the cursor up `«n»` rows                     |
+        /// | `␛[«n»B`    | Move the cursor down `«n»` rows                   |
+        /// | `␛[«n»C`    | Move the cursor right `«n»` column                |
+        /// | `␛[«n»D`    | Move the cursor left `«n»` columns                |
+        /// | `␛[«n»G`    | Move the cursor to column `«n»`                   |
+        /// | `␛[«row»;«column»H` | Move the cursor to row `«row»` and column `«column»` |
+        /// | `␛[0J`      | Clear from the cursor to the end of the screen    |
+        /// | `␛[1J`      | Clear the screen from the beginning to the current cursor position |
+        /// | `␛[2J`      | Clear the whole screen                            |
+        /// | `␛[«n»d`    | Move the cursor to row `«n»`                      |
+        /// | `␛[«row»;«column»f` | Move the cursor to row `«row»` and column `«column»` |
+        /// | `␛[?25h`    | Set the cursor as visible                         |
+        /// | `␛[?1049h`  | Clear the screen and reset full-screen settings to defaults |
+        /// | `␛[?2004h`  | Begin bracketed paste mode                        |
+        /// | `␛[?25l`    | Set the cursor as invisible                       |
+        /// | `␛[?1049l`  | Exit full-screen mode and restore the terminal to its prior state |
+        /// | `␛[?2004l`  | End bracketed paste mode                          |
+        /// | `␛[!p`      | Reset the terminal to default settings, without clearing the screen |
+        full-screen-supported: func() -> bool
+    }
+
+    /// Flags indicating support for different sets of color escape
+    /// sequences, and the user's preference for whether they should
+    /// be used by default.
+    ///
+    /// Other color features, including 88-color and 256-color are not
+    /// included here, as the associated escape sequences are not as
+    /// portable, and they're effectively obviated by truecolor support.
+    flags color-flags {
+        /// Are the classic "4-bit color" escape sequences supported?
+        ///
+        /// This indicates support for up to 16 colors, on foreground and
+        /// background, using the widely-supported (and ECMA-48) "SGR"
+        /// color escape sequences of the form `␛[…m`. See
+        /// [here] for more information.
+        ///
+        /// Before using color in your user interface, also consider
+        /// checking `color-desired` to obtain the user's preference for
+        /// enabling color by default.
+        ///
+        /// [here]: https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
+        ansi,
+
+        /// Are the 24-bit "true color" escape sequences supported?
+        ///
+        /// This indicates support for up to 16 colors, on foreground and
+        /// background, using "true color" escape sequences of the form
+        /// `␛[38;2;«r»;«g»;«b»m` (foreground) and `␛[48;2;«r»;«g»;«b»m`
+        /// (background). The `«r»`, `«g»`, and `«b»` fields are integers
+        /// in the range [0,256) indicating red, green, and blue values
+        /// respectively. See /// [here] for more information.
+        ///
+        /// Before using color in your user interface, also consider
+        /// checking `color-desired` to obtain the user's preference for
+        /// enabling color by default.
+        ///
+        /// [here]: https://en.wikipedia.org/wiki/ANSI_escape_code#24-bit
+        truecolor,
+
+        /// Does the user with color to be used by default?
+        ///
+        /// Some users have a terminal which supports color, but prefer
+        /// applications not use it by default; this flag indicates
+        /// this preference.
+        ///
+        /// See the [`NO_COLOR` website](http://no-color.org/) for more
+        /// information.
+        color-desired-by-default,
+    }
+
+    /// A pair of rows and columns.
+    record rows-and-columns {
+        rows: u16,
+        columns: u16,
     }
 }
 


### PR DESCRIPTION
Add a simple terminal API defining functions for querying and configuring terminal attributes, as well as a preliminary description of escape sequences along with a set of recommendations for implementors.